### PR TITLE
Add long press support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Lovelace Button card for your entities.
 
   - works with any toggleable entity
   - 3 actions on tap `toggle`, `more_info` and `service`
+  - 3 actions on longpress `toggle`, `more_info` and `service`
   - state display (optional)
   - custom color for `on` and `off` state (optional)
   - custom state definition with customizable color (optional)
@@ -36,6 +37,7 @@ Lovelace Button card for your entities.
 | color_off | string | `var(--disabled-text-color)` | `rgb(28, 128, 199)` |  Color of the icon/card when state is `off`.
 | size | string | `40%` | `20px` | Size of the icon. Can be percentage or pixel
 | action | string | `toggle` | `toggle` \| `more_info` \| `service` | Define the type of action
+| long_press_action | string | `toggle` | `toggle` \| `more_info` \| `service` | Define the type of action for a long press (>500 milliseconds)
 | service | Object | optional | See [example section](examples) | Service to call and service data when action is set to `service`
 | name | string | optional | `Air conditioner` | Define an optional text to show below the icon
 | show_state | boolean | `false` | `true` \| `false` | Show the state on the card. defaults to false if not set

--- a/button-card.js
+++ b/button-card.js
@@ -10,14 +10,12 @@ class ButtonCard extends LitElement {
       held: Boolean,
       cancel: Boolean,
       timer: Number,
-      holdTime: Number,
       xStart: Number,
       yStart: Number
     };
   }
 
   _render({ hass, config }) {
-    this.holdTime = 500;
     const state = hass.states[config.entity];
     switch (config.color_type) {
       case 'blank-card':
@@ -215,7 +213,7 @@ class ButtonCard extends LitElement {
     this.yStart = event.detail.y;
     this.timer = window.setTimeout(() => {
         this.held = true;
-      }, this.holdTime);
+      }, 500);
   }
 
   _up(event, state, config) {


### PR DESCRIPTION
This is to add long press support to the button-card. Changes were made to allow for tracking the length of the user pressing and the x-y coordinates. 

If the user pressed for <500 milliseconds it is counted as a single click. 

If the user presses for >500 milliseconds it is counted as a long press.

Also tweaked the code to allow for "more-info" or "more_info", since the other HASS standard lovelace items use the "-" 

Please note, I'm pretty new at this, so let me know if I did something wrong. 

Fixes #55 