### PR TITLE
Color when climate is in "heat" state

### DIFF
--- a/button-card.js
+++ b/button-card.js
@@ -64,8 +64,7 @@ class ButtonCard extends LitElement {
         if (config.color === 'auto') {
           color = state.attributes.rgb_color ? `rgb(${state.attributes.rgb_color.join(',')})` : config.default_color;
         }
-        color = state.state === 'on' ? color : config.color_off;
-      }
+        color = state.state === 'heat' ? color : state.state === 'on' ? color : config.color_off;      }
     }
     return color;
   }


### PR DESCRIPTION
As the button can be colored when entity is "on", this simple patch will also enable enlighting the button when thermostat is in "heat" state