### PR TITLE
adds show_icon: false to the text-only config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Show an ON/OFF button for the home_lights group:
 ```yaml
 - type: "custom:button-card"
   entity: group.home_lights
+  show_icon: false
   show_state: true
 ```
 


### PR DESCRIPTION
This adds `show_icon: false` to the "no icon" text only configuration example. 

This line is necessary now because after recent changes the card automatically uses the default icon for that entity_id as a fallback if there's no mdi: icon specified. 

Issue was pointed out by arsaboo in [this forum post](https://community.home-assistant.io/t/lovelace-button-card/65981/595) and has a screenshot of how it looks without this line.