### PR TITLE
tap_action location was changed to navigate

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,9 +335,9 @@ The definition order matters, the first item to match will be the one selected.
         - opacity: 0.5
 ```
 
-#### `tap_action` Location
+#### `tap_action` Navigate
 
-For example, you can switch panel with the `location` action:
+Buttons can link to different views using the `navigate` action:
 
 ```yaml
 - type: "custom:button-card"
@@ -345,9 +345,11 @@ For example, you can switch panel with the `location` action:
   icon: mdi:home
   name: Go To Home
   tap_action:
-    action: location
+    action: navigate
     navigation_path: /lovelace/0
 ```
+
+The `navigation_path` also accepts any Home Assistant internal URL such as /dev-info or /hassio/dashboard for example.
 
 #### blink
 


### PR DESCRIPTION
Original commit used `location` but it was later changed to `navigate` to be more consistent with HA core. This just fixes docs to match the finalized naming scheme. 

Also added a note that navigation_path can link to internal HA URL's.