### PR TITLE
Support for URL in tap_action

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,13 @@ Lovelace Button card for your entities.
 
 ### Action
 
-| Name              | Type   | Default  | Supported options                                         | Description                                                                                              |
-| ----------------- | ------ | -------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `action`          | string | `toggle` | `more-info`, `toggle`, `call-service`, `none`, `navigate` | Action to perform                                                                                        |
-| `navigation_path` | string | none     | Eg: `/lovelace/0/`                                        | Path to navigate to (e.g. `/lovelace/0/`) when action defined as navigate                                |
-| `service`         | string | none     | Any service                                               | Service to call (e.g. `media_player.media_play_pause`) when `action` defined as `call-service`           |
-| `service_data`    | object | none     | Any service data                                          | Service data to include (e.g. `entity_id: media_player.bedroom`) when `action` defined as `call-service` |
+| Name              | Type   | Default  | Supported options                                                | Description                                                                                              |
+| ----------------- | ------ | -------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `action`          | string | `toggle` | `more-info`, `toggle`, `call-service`, `none`, `navigate`, `url` | Action to perform                                                                                        |
+| `navigation_path` | string | none     | Eg: `/lovelace/0/`                                               | Path to navigate to (e.g. `/lovelace/0/`) when action defined as navigate                                |
+| `url`             | string | none     | Eg: `https://www.google.fr`                                      | URL to open on click when action is `url`. The URL will open in a new tab                                |
+| `service`         | string | none     | Any service                                                      | Service to call (e.g. `media_player.media_play_pause`) when `action` defined as `call-service`           |
+| `service_data`    | object | none     | Any service data                                                 | Service data to include (e.g. `entity_id: media_player.bedroom`) when `action` defined as `call-service` |
 
 ### State
 

--- a/button-card.js
+++ b/button-card.js
@@ -482,6 +482,9 @@ export default function domainIcon(domain, state) {
             const [domain, service] = config.tap_action.service.split('.', 2);
             this.hass.callService(domain, service, config.tap_action.service_data);
             break;
+          case 'url':
+            config.tap_action.url && window.open(config.tap_action.url);
+            break;
           case 'toggle':
           default:
             this.hass.callService('homeassistant', 'toggle', {


### PR DESCRIPTION
Support for `url` as an action. Fix #87 
```yaml
- type: "custom:button-card"
  icon: mdi:link
  name: url
  tap_action:
    action: url
    url: https://www.google.com
```
