### PR TITLE
Fix brightness calculation & Longpress in some cases

### DIFF
--- a/dist/button-card.js
+++ b/dist/button-card.js
@@ -3330,7 +3330,7 @@ function buildNameStateConcat(name, stateString) {
 function applyBrightnessToColor(color, brightness) {
     const colorObj = new TinyColor(getColorFromVariable(color));
     if (colorObj.isValid) {
-        const validColor = colorObj.darken(100 - brightness).toString();
+        const validColor = colorObj.mix('black', 100 - brightness).toString();
         if (validColor) return validColor;
     }
     return color;

--- a/dist/button-card.js
+++ b/dist/button-card.js
@@ -3614,10 +3614,10 @@ class LongPress extends HTMLElement {
 customElements.define("long-press-button-card", LongPress);
 const getLongPress = () => {
     const body = document.body;
-    if (body.querySelector("long-press")) {
-        return body.querySelector("long-press");
+    if (body.querySelector("long-press-button-card")) {
+        return body.querySelector("long-press-button-card");
     }
-    const longpress = document.createElement("long-press");
+    const longpress = document.createElement("long-press-button-card");
     body.appendChild(longpress);
     return longpress;
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -51,7 +51,7 @@ export function applyBrightnessToColor(
 ): string {
   const colorObj = new TinyColor(getColorFromVariable(color));
   if (colorObj.isValid) {
-    const validColor = colorObj.darken(100 - brightness).toString();
+    const validColor = colorObj.mix('black', 100 - brightness).toString();
     if (validColor) return validColor;
   }
   return color;

--- a/src/long-press.ts
+++ b/src/long-press.ts
@@ -164,11 +164,11 @@ customElements.define("long-press-button-card", LongPress);
 
 const getLongPress = (): LongPress => {
   const body = document.body;
-  if (body.querySelector("long-press")) {
-    return body.querySelector("long-press") as LongPress;
+  if (body.querySelector("long-press-button-card")) {
+    return body.querySelector("long-press-button-card") as LongPress;
   }
 
-  const longpress = document.createElement("long-press");
+  const longpress = document.createElement("long-press-button-card");
   body.appendChild(longpress);
 
   return longpress as LongPress;


### PR DESCRIPTION
**Fixes**
* Brightness calculation for lights was different than the default from Home Assistant. This is fixed.
* Own longpress was not used in some cases