### PR TITLE
Only specific users can disable the lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Lovelace Button card for your entities.
 | `state`        | object list | optional     | See [State](#State)                              | State to use for the color, icon and style of the button. Multiple states can be defined                                                                                                                                                                                                                                                      |
 | `confirmation` | string     | optional      | Free-form text                               | Show a confirmation popup on tap with defined text                                                                                                                                                                                                                                                                                                            |
 | `lock` | boolean | `false` | `true` \| `false` | See [lock](#lock). This will display a normal button with a lock symbol in the corner. Clicking the button will make the lock go away and enable the button to be manoeuvred for five seconds |
+| `unlock_users` | string list | optional | A list of users | List of users allowed to unlock the button when `lock: true`. If not defined, everyone is allowed to unlock the button |
 | `layout` | string | optional | See [Layout](#Layout) | The layout of the button can be modified using this option |
 
 ### Action

--- a/dist/button-card.js
+++ b/dist/button-card.js
@@ -1679,7 +1679,9 @@ window.navigator.userAgent.match("Trident") && (DOMTokenList.prototype.toggle = 
   }_handleDblTap(t) {
     if (this.config.confirmation && !window.confirm(this.config.confirmation)) return;const e = t.target.config;Ot(this, this.hass, e, !1, !0);
   }_handleLock(t) {
-    t.stopPropagation();const e = this.shadowRoot.getElementById("overlay"),
+    if (t.stopPropagation(), this.config.unlock_users) {
+      if (!this.hass.user.name) return;if (this.config.unlock_users.indexOf(this.hass.user.name) < 0) return;
+    }const e = this.shadowRoot.getElementById("overlay"),
           n = this.shadowRoot.getElementById("card");e.style.setProperty("pointer-events", "none");const i = document.createElement("paper-ripple"),
           r = this.shadowRoot.getElementById("lock");if (r) {
       n.appendChild(i);const t = document.createAttribute("icon");t.value = "mdi:lock-open-outline", r.attributes.setNamedItem(t), r.classList.add("fadeOut");

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -674,6 +674,10 @@ class ButtonCard extends LitElement {
 
   private _handleLock(ev): void {
     ev.stopPropagation();
+    if (this.config!.unlock_users) {
+      if (!this.hass!.user.name) return;
+      if (this.config!.unlock_users.indexOf(this.hass!.user.name) < 0) return;
+    }
     const overlay = this.shadowRoot!.getElementById('overlay') as LitElement;
     const haCard = this.shadowRoot!.getElementById('card') as LitElement;
     overlay.style.setProperty('pointer-events', 'none');

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface ButtonCardConfig {
   size: string;
   aspect_ratio?: string;
   lock: boolean;
+  unlock_users?: string[];
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;
   dbltap_action?: ActionConfig;


### PR DESCRIPTION
**NEW FEATURES**
* New option: `unlock_users`: A list of usernames allowed to unlock the button when `lock: true`. If undefined, everyone is allowed. (Fixed #167)
  ```yaml
  - type: custom:button-card
    entity: switch.super_secure_switch
    lock: true
    unlock_users:
      - user1
      - user2
  ```