### PR TITLE
2.0.2

### DIFF
--- a/dist/button-card.js
+++ b/dist/button-card.js
@@ -1536,7 +1536,7 @@ const ct = new WeakMap(),
   }_evalTemplate(t, e) {
     return new Function("states", "entity", "user", "hass", `'use strict'; ${e}`).call(this, this.hass.states, t, this.hass.user, this.hass);
   }_getTemplateOrValue(t, e) {
-    if ("number" == typeof e) return e;if (!e) return;const n = e.trim();return "[[[" === n.substring(0, 3) && "]]]" === n.slice(-3) ? this._evalTemplate(t, n.slice(3, -3)) : e;
+    if (["number", "boolean"].includes(typeof e)) return e;if (!e) return;const n = e.trim();return "[[[" === n.substring(0, 3) && "]]]" === n.slice(-3) ? this._evalTemplate(t, n.slice(3, -3)) : e;
   }_getDefaultColorForState(t) {
     switch (t.state) {case "on":
         return this.config.color_on;case "off":

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "button-card",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "button-card",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Button card for lovelace",
   "main": "dist/button-card.js",
   "pre-commit": [

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -214,7 +214,7 @@ class ButtonCard extends LitElement {
     state: HassEntity | undefined,
     value: any | undefined,
   ): any | undefined {
-    if (typeof value === 'number') return value;
+    if (['number', 'boolean'].includes(typeof value)) return value;
     if (!value) return undefined;
     const trimmed = value.trim();
     if (


### PR DESCRIPTION
**BUGFIXES**
* If a field with template support had the number `0` as a value, the field's value would be transformed into `undefined`
* When in an `*_action` the `service_data` field contained parameters which where objects or booleans, an error was thrown and the action wouldn't execute.
