### PR TITLE
3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "button-card",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "button-card",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Button card for lovelace",
   "main": "dist/button-card.js",
   "pre-commit": [

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -22,6 +22,7 @@ import {
   secondsToDuration,
   durationToSeconds,
   createThing,
+  DOMAINS_TOGGLE,
 } from 'custom-card-helpers';
 import { BUTTON_CARD_VERSION } from './version-const';
 import {
@@ -855,7 +856,6 @@ class ButtonCard extends LitElement {
     }
     template.state = mergedStateConfig;
     this.config = {
-      tap_action: { action: 'toggle' },
       hold_action: { action: 'none' },
       double_tap_action: { action: 'none' },
       layout: 'vertical',
@@ -870,6 +870,17 @@ class ButtonCard extends LitElement {
       show_live_stream: false,
       ...template,
     };
+    if (this.config!.entity && DOMAINS_TOGGLE.has(computeDomain(this.config!.entity))) {
+      this.config = {
+        tap_action: { action: 'toggle' },
+        ...this.config,
+      };
+    } else {
+      this.config = {
+        tap_action: { action: 'more-info' },
+        ...this.config,
+      };
+    }
     this.config.lock = {
       enabled: false,
       duration: 5,

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -3,6 +3,7 @@ import { css } from 'lit-element';
 export const styles = css`
   :host {
     position: relative;
+    display: block;
   }
   ha-card {
     cursor: pointer;

--- a/src/version-const.ts
+++ b/src/version-const.ts
@@ -1,1 +1,1 @@
-export const BUTTON_CARD_VERSION = '3.2.1';
+export const BUTTON_CARD_VERSION = '3.2.2';


### PR DESCRIPTION
# Bugfixes
* Lock disappearing when used with decluttering-card (Might fix #298)
* The default `tap_action` is now `toggle` only for entities which support toggle, else it's `more-info`