### PR TITLE
change the card size to 2 per button

### DIFF
--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -997,7 +997,7 @@ class ButtonCard extends LitElement {
   // The height of your card. Home Assistant uses this to automatically
   // distribute all cards over the available columns.
   public getCardSize(): number {
-    return 3;
+    return 2;
   }
 
   private _evalActions(config: ButtonCardConfig, action: string): ButtonCardConfig {


### PR DESCRIPTION
This is more reasonable. A button is about the size of 2 entity rows.

See for example here:
![image](https://user-images.githubusercontent.com/6897215/84598727-1f6b1080-ae6d-11ea-8834-c09de7becb9d.png)


Here the columns aren't of equal length because each button is size three, meaning that it's is the same size as the left bottom most card (three entity rows).