### PR TITLE
fix blank-card

### DIFF
--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -669,6 +669,7 @@ class ButtonCard extends LitElement {
     const blankCardStyle = {
       background: 'none',
       'box-shadow': 'none',
+      'border-style': 'none',
       ...cardStyle,
     };
     return html`


### PR DESCRIPTION
The blank card shows on HA 2022.11.0 and later are border as show below:
![image](https://user-images.githubusercontent.com/26537646/199749899-06a16cf4-e9e4-484b-8bee-dc339107f230.png)

With this PR this border is gone:
![image](https://user-images.githubusercontent.com/26537646/199750148-07357a75-cfb1-4149-a131-99b2883e88aa.png)

I tested this fix successfully for 2022.10.5 to verify that it is backwards compatible. 

Workaround until this PR is merged:
```yaml
type: custom:button-card
color_type: blank-card
styles:
  card:
    - border-style: none
``` 