### PR TITLE
Don't trigger action on touchcancel event

### DIFF
--- a/src/action-handler.ts
+++ b/src/action-handler.ts
@@ -179,6 +179,12 @@ class ActionHandler extends HTMLElement implements ActionHandler {
         }
         return;
       }
+
+      // Don't do anything else if touch event was cancelled
+      if (ev.type == 'touchcancel') {
+        return;
+      }
+
       const target = ev.target as HTMLElement;
       // Prevent mouse event if touch event
       if (ev.cancelable) {


### PR DESCRIPTION
When using the Android Navigation Back Gesture (swipe from side of screen), tap actions are still triggered even though Android sent a touchcancel event.

This changes makes it so that a touchcancel event does not trigger actions.