### PR TITLE
Add stop_propagation config option to stop click or touch events propagation

### DIFF
--- a/src/action-handler.ts
+++ b/src/action-handler.ts
@@ -23,6 +23,7 @@ export interface ActionHandlerOptions {
   hasHold?: boolean;
   hasDoubleClick?: boolean;
   disabled?: boolean;
+  stopPropagation?: boolean;
   repeat?: number;
   repeatLimit?: number;
 }
@@ -138,6 +139,9 @@ class ActionHandler extends HTMLElement implements ActionHandler {
     }
 
     element.actionHandler.start = (ev: Event) => {
+      if (options.stopPropagation) {
+        ev.stopPropagation();
+      }
       this.cancelled = false;
       let x;
       let y;
@@ -171,6 +175,9 @@ class ActionHandler extends HTMLElement implements ActionHandler {
     };
 
     element.actionHandler.end = (ev: Event) => {
+      if (options.stopPropagation) {
+        ev.stopPropagation();
+      }
       // Don't respond when moved or scrolled while touch
       if (['touchend', 'touchcancel'].includes(ev.type) && this.cancelled) {
         if (this.isRepeating && this.repeatTimeout) {

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -998,6 +998,7 @@ class ButtonCard extends LitElement {
           .actionHandler=${actionHandler({
             hasDoubleClick: this._config!.double_tap_action!.action !== 'none',
             hasHold: this._config!.hold_action!.action !== 'none',
+            stopPropagation: this._config!.stop_propagation,
             repeat: this._config!.hold_action!.repeat,
             repeatLimit: this._config!.hold_action!.repeat_limit,
           })}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -18,6 +18,7 @@ export interface ButtonCardConfig {
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
+  stop_propagation?: boolean;
   show_name?: boolean;
   show_state?: boolean;
   show_icon?: boolean;
@@ -58,6 +59,7 @@ export interface ExternalButtonCardConfig {
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
+  stop_propagation?: boolean;
   show_name?: boolean;
   show_state?: boolean;
   show_icon?: boolean;


### PR DESCRIPTION
Useful when using button-card inside another card.
Making it a config option instead of always applying it because of [this comment](https://github.com/custom-cards/button-card/issues/200#issuecomment-516451787).

For an example application, when using a button-card, inside the `title-card` of [lovelace-expander-card](https://github.com/MelleD/lovelace-expander-card) with `title-card-clickable`. In this case, when clicking a button-card with a tap action, letting the click/touch event bubble up would also unintentionally expand/collapse the expander card.