### PR TITLE
Update button-card errors

### DIFF
--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -113,6 +113,8 @@ class ButtonCard extends LitElement {
 
   @property() private _timeRemaining?: number;
 
+  @property({ type: Boolean, reflect: true }) preview = false;
+
   @queryAsync('mwc-ripple') private _ripple!: Promise<Ripple | null>;
 
   private _hasTemplate?: boolean;
@@ -282,10 +284,11 @@ class ButtonCard extends LitElement {
       if (e.stack) console.error(e.stack);
       else console.error(e);
       const errorCard = document.createElement('hui-error-card') as LovelaceCard;
+      errorCard.preview = this.preview;
       errorCard.setConfig({
         type: 'error',
-        error: e.toString(),
-        origConfig: this._config,
+        error: e.name,
+        message: e.message,
       });
       return html` ${errorCard} `;
     }
@@ -296,8 +299,19 @@ class ButtonCard extends LitElement {
     if (forceUpdate || myHasConfigOrEntityChanged(this, changedProps)) {
       this._expandTriggerGroups();
       return true;
+    } else if (changedProps.has('preview')) {
+      return true;
     }
     return false;
+  }
+
+  protected willUpdate(changedProps: PropertyValues): void {
+    if (changedProps.has('preview')) {
+      Object.keys(this._cards).forEach((element) => {
+        const el = this._cards[element];
+        el.preview = this.preview;
+      });
+    }
   }
 
   protected updated(changedProps: PropertyValues): void {
@@ -842,6 +856,7 @@ class ButtonCard extends LitElement {
         let thing;
         if (!deepEqual(this._cardsConfig[key], cards[key])) {
           thing = this._createCard(cards[key]);
+          thing.preview = this.preview;
           this._cards[key] = thing;
           this._cardsConfig[key] = copy(cards[key]);
         } else {

--- a/src/types/lovelace.ts
+++ b/src/types/lovelace.ts
@@ -21,6 +21,7 @@ export interface LovelaceCard extends HTMLElement {
   hass?: HomeAssistant;
   isPanel?: boolean;
   editMode?: boolean;
+  preview?: boolean;
   getCardSize(): number | Promise<number>;
   setConfig(config: LovelaceCardConfig): void;
 }
@@ -211,7 +212,7 @@ export type ActionConfig =
   | NoActionConfig
   | CustomActionConfig;
 
-type LovelaceUpdatedEvent = HassEventBase & {
+export type LovelaceUpdatedEvent = HassEventBase & {
   event_type: 'lovelace_updated';
   data: {
     url_path: string | null;


### PR DESCRIPTION
Since earlier this year HA Frontend revamped error card display. Now only error will show in normal mode, and message will only show in preview/edit mode, but only if the card and child cards has preview property correctly set.

The old method of `origConfig` seems only retained for badges. So in this PR I have set `error` to `e.name` and message to `e.message`. Looks to work well. 2 examples below.

## Bad JS Template
### Normal
<img width="559" height="139" alt="Screenshot 2025-08-25 at 6 54 39 pm" src="https://github.com/user-attachments/assets/93ffda57-c993-4ad0-acb8-85b875c5f29f" />
### Edit dashboard
<img width="515" height="180" alt="Screenshot 2025-08-25 at 6 54 54 pm" src="https://github.com/user-attachments/assets/66c9dc41-73c4-4732-affb-229d0a816290" />
### Edit card
<img width="458" height="367" alt="Screenshot 2025-08-25 at 6 55 09 pm" src="https://github.com/user-attachments/assets/5cb5cb4e-7d28-4507-9fdd-9dc35436d12f" />

## Custom field card error
### Normal
<img width="507" height="276" alt="Screenshot 2025-08-25 at 9 26 56 pm" src="https://github.com/user-attachments/assets/a716110b-e009-4056-ab9c-4d2d7bc774b5" />
### Edit dashboard
<img width="507" height="329" alt="Screenshot 2025-08-25 at 9 27 07 pm" src="https://github.com/user-attachments/assets/3940beaf-df55-482d-b0a8-8b463ae07117" />
### Edit card
<img width="474" height="471" alt="Screenshot 2025-08-25 at 9 27 21 pm" src="https://github.com/user-attachments/assets/e32c9510-6baf-4d4f-8911-367161e16304" />
