### PR TITLE
feat(lock): Option to keep the unlock icon displayed and define custom lock/unlock icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ confirmation:
 
 ### Lock Object
 
-This will display a normal button with a lock symbol in the corner. Clicking the button will make the lock go away and enable the button to be manoeuvred for `delay` seconds (5 by default).
+This will display a normal button with a lock symbol in the corner. Clicking the button will make the lock go away and enable the button to be manoeuvred for `duration` seconds (5 by default).
 
 | Name | Type | Default | Supported options | Description |
 | --- | --- | --- | --- | --- |
@@ -216,6 +216,9 @@ This will display a normal button with a lock symbol in the corner. Clicking the
 | `duration` | number | `5` | any number | Duration of the unlocked state in seconds |
 | `exemptions` | array of user id or username | none | `user: USER_ID` \| `username: test` | Any user declared in this list will not see the confirmation dialog. It can be a user id (`user`) or a username (`username`) |
 | `unlock` | string | `tap` | `tap` \| `hold` \| `double_tap` | The type of click which will unlock the button |
+| `keep_unlock_icon` | boolean | `false` | `true` \| `false` | If `true`, the `unlock_icon` icon will stay visible when the card is unlocked |
+| `lock_icon` | string | `mdi:lock-outline` | any HA icon | The icon when the card is locked |
+| `unlock_icon` | string | `mdi:lock-open-outline` | any HA icon | The icon displayed when the card is unlocked |
 
 Example:
 

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -85,6 +85,7 @@ import {
   formatDateWeekdayShort,
   formatDateYear,
 } from './common/format_date';
+import { DEFAULT_LOCK_DURATION, DEFAULT_LOCK_ICON, DEFAULT_UNLOCK_ICON } from './const';
 
 let helpers = (window as any).cardHelpers;
 const helperPromise = new Promise<void>(async (resolve) => {
@@ -1099,7 +1100,7 @@ class ButtonCard extends LitElement {
           })}
           .config="${this._config}"
         >
-          <ha-icon id="lock" icon="mdi:lock-outline"></ha-icon>
+          <ha-icon id="lock" icon=${this._config!.lock.lock_icon}></ha-icon>
         </div>
       `;
     }
@@ -1319,8 +1320,10 @@ class ButtonCard extends LitElement {
       ...template,
       lock: {
         enabled: false,
-        duration: 5,
+        duration: DEFAULT_LOCK_DURATION,
         unlock: 'tap',
+        lock_icon: DEFAULT_LOCK_ICON,
+        unlock_icon: DEFAULT_UNLOCK_ICON,
         ...template.lock,
       },
     };
@@ -1487,18 +1490,18 @@ class ButtonCard extends LitElement {
     overlay.style.setProperty('pointer-events', 'none');
 
     if (lock) {
-      const icon = document.createAttribute('icon');
-      icon.value = 'mdi:lock-open-outline';
-      lock.attributes.setNamedItem(icon);
-      lock.classList.add('hidden');
+      (lock as any).icon = this._config!.lock.unlock_icon;
+      if (!this._config?.lock?.keep_unlock_icon) {
+        lock.classList.add('hidden');
+      }
     }
     window.setTimeout(() => {
       overlay.style.setProperty('pointer-events', '');
       if (lock) {
-        lock.classList.remove('hidden');
-        const icon = document.createAttribute('icon');
-        icon.value = 'mdi:lock-outline';
-        lock.attributes.setNamedItem(icon);
+        if (!this._config?.lock?.keep_unlock_icon) {
+          lock.classList.remove('hidden');
+        }
+        (lock as any).icon = this._config!.lock!.lock_icon;
       }
     }, this._config!.lock!.duration! * 1000);
   }

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_LOCK_ICON = 'mdi:lock-outline';
+export const DEFAULT_UNLOCK_ICON = 'mdi:lock-open-outline';
+export const DEFAULT_LOCK_DURATION = 5;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -107,6 +107,9 @@ export type ColorType = 'icon' | 'card' | 'label-card' | 'blank-card';
 export interface LockConfig {
   enabled: boolean;
   duration: number;
+  keep_unlock_icon?: boolean;
+  lock_icon: string;
+  unlock_icon: string;
   unlock: 'tap' | 'double_tap' | 'hold';
   exemptions?: (ExemptionUserConfig | ExemptionUsernameConfig)[];
 }

--- a/test/ui-lovelace.yaml
+++ b/test/ui-lovelace.yaml
@@ -2161,6 +2161,9 @@ views:
                 color_type: card
                 lock:
                   enabled: true
+                  keep_unlock_icon: true
+                  lock_icon: mdi:lightbulb
+                  unlock_icon: mdi:fire
                 color: black
                 entity: switch.skylight
                 show_label: true


### PR DESCRIPTION
Closes #842

For eg:
```yaml
type: custom:button-card
entity: light.skylight
lock:
  enabled: true
  keep_unlock_icon: true
  lock_icon: mdi:close-octagon
  unlock_icon: mdi:thumb-up
```