### PR TITLE
fix: Move while hold on touch devices

### DIFF
--- a/src/action-handler.ts
+++ b/src/action-handler.ts
@@ -225,7 +225,7 @@ class ActionHandler extends HTMLElement implements ActionHandler {
         ev.stopPropagation();
         ev.preventDefault();
       }
-    }
+    };
 
     element.actionHandler.handleEnter = (ev: KeyboardEvent) => {
       if (ev.keyCode !== 13) {

--- a/src/action-handler.ts
+++ b/src/action-handler.ts
@@ -33,6 +33,7 @@ interface ActionHandlerElement extends HTMLElement {
     start?: (ev: Event) => void;
     end?: (ev: Event) => void;
     handleEnter?: (ev: KeyboardEvent) => void;
+    handleTouchMove?: (ev: TouchEvent) => void;
   };
 }
 
@@ -219,6 +220,13 @@ class ActionHandler extends HTMLElement implements ActionHandler {
       }
     };
 
+    element.actionHandler.handleTouchMove = (ev: TouchEvent) => {
+      if (ev.type == 'touchmove' && options.hasHold && this.held) {
+        ev.stopPropagation();
+        ev.preventDefault();
+      }
+    }
+
     element.actionHandler.handleEnter = (ev: KeyboardEvent) => {
       if (ev.keyCode !== 13) {
         return;
@@ -229,6 +237,7 @@ class ActionHandler extends HTMLElement implements ActionHandler {
     element.addEventListener('touchstart', element.actionHandler.start, {
       passive: true,
     });
+    element.addEventListener('touchmove', element.actionHandler.handleTouchMove);
     element.addEventListener('touchend', element.actionHandler.end);
     element.addEventListener('touchcancel', element.actionHandler.end);
 


### PR DESCRIPTION
Found this while working though touch events. A straighforward non-breaking change that fixes an issue. Can be tested by putting Chrome in touch device mode in developer console.

Video with PR:

https://github.com/user-attachments/assets/a5dc5b46-d60a-4180-9443-3aebc8a95f46



