### PR TITLE
feature(actions): migrate to ha-ripple

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Lovelace Button card for your entities.
     - [Merging state by id](#merging-state-by-id)
     - [Variables](#variables)
   - [Changing the feedback color during button/icon hover and click](#changing-the-feedback-color-during-buttonicon-hover-and-click)
+    - [Ripple and hover color CSS variables names](#ripple-and-hover-color-css-variables-names)
     - [Icon hover and click size \& shape](#icon-hover-and-click-size--shape)
 - [Installation](#installation)
   - [Installation and tracking with `HACS`](#installation-and-tracking-with-hacs)
@@ -1144,6 +1145,8 @@ name: '[[[ return variables.value; ]]]'
 ```
 
 ### Changing the feedback color during button/icon hover and click
+
+#### Ripple and hover color CSS variables names
 
 Buttons will provide hover feedback (ripple) when an action is available. When the icon also has an action, the hover opacity will be slightly less to indicate this. When button/icon is pressed, the opacity will be less to indicate the button/icon is pressed. You can style color and opacity for hover and pressed states using the following CSS variables for `card`.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Lovelace Button card for your entities.
     - [General](#general)
     - [Merging state by id](#merging-state-by-id)
     - [Variables](#variables)
+  - [Changing the feedback color during button/icon hover and click](#changing-the-feedback-color-during-buttonicon-hover-and-click)
+    - [Icon hover and click size \& shape](#icon-hover-and-click-size--shape)
 - [Installation](#installation)
   - [Installation and tracking with `HACS`](#installation-and-tracking-with-hacs)
   - [Manual Installation](#manual-installation)
@@ -64,7 +66,6 @@ Lovelace Button card for your entities.
   - [Styling](#styling)
   - [Lock](#lock)
   - [Aspect Ratio](#aspect-ratio)
-  - [Changing the feedback color during a click](#changing-the-feedback-color-during-a-click)
 - [Community guides](#community-guides)
 - [Credits](#credits)
 
@@ -1142,6 +1143,87 @@ variables:
 name: '[[[ return variables.value; ]]]'
 ```
 
+### Changing the feedback color during button/icon hover and click
+
+Buttons will provide hover feedback (ripple) when an action is available. When the icon also has an action, the hover opacity will be slightly less to indicate this. When button/icon is pressed, the opacity will be less to indicate the button/icon is pressed. You can style color and opacity for hover and pressed states using the following CSS variables for `card`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `--button-card-ripple-color` | Follows `color` of button card | Base color of main button background when hovering over a button with an action |
+| `--button-card-ripple-hover-color` | `--button-card-ripple-color` | Color of main button background when hovering over a button with an action |
+| `--button-card-ripple-pressed-color` | `--button-card-ripple-color` | Color of main button background when button with an action is pressed |
+| `--button-card-ripple-hover-opacity` | 0.08 | Opacity of main button backgrond when hovering over a button with an action |
+| `--button-card-ripple-pressed-opacity` | 0.12 | Opacity of main button when a button with an action is pressed |
+| `--button-card-ripple-icon-color` | `--button-card-ripple-color` | Color of icon background when hovering over an icon with an action |
+| `--button-card-ripple-pressed-color` | `--button-card-ripple-hover-color` | Color of icon background when an icon with an action is pressed |
+| `--button-card-ripple-icon-hover-opacity` | `--button-card-ripple-hover-opacity` + 0.05 | Opacity of icon background when hovering over an icon with an action |
+| `--button-card-ripple-icon-pressed-opacity` | `--button-card-ripple-pressed-opacity` + 0.05 | Opacity of icon background when an icon with an action is pressed |
+
+Example to set hover to follow light color rather than standard state color:
+
+```yaml
+styles:
+  icon:
+    - color: var(--button-card-light-color)
+  card:
+    - --button-card-ripple-color: var(--button-card-light-color)
+```
+
+Example to set icon hover color and hover & pressed opacity:
+
+```yaml
+styles:
+  card:
+    - --button-card-ripple-icon-hover-opacity: 0.3
+    - --button-card-ripple-icon-press-opacity: 0.6
+    - --button-card-ripple-icon-color: red
+```
+
+#### Icon hover and click size & shape
+
+The size of the icon hover background is calculated dynamically from the icon size with padding.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `--button-card-ripple-icon-inset` | Dynamic | Any valid [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) value. |
+| `--button-card-ripple-icon-border-radius` | `--ha-card-border-radius` or 12px | Any valid [`border-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius) value. |
+| `--button-card-ripple-icon-inset-padding` | 12 | A single numerical value used to pad out the icon hover background by this value in pixels. |
+
+Example to extend icon hover to button size but set different icon hover color:
+
+```yaml
+styles:
+  card:
+    - --button-card-ripple-icon-inset: 0
+    - --button-card-ripple-icon-color: red
+```
+
+Example to set a minimal inset for icon hover:
+
+```yaml
+styles:
+  card:
+    - --button-card-ripple-icon-inset: 5px
+```
+
+Example to set no padding for icon hover:
+
+```yaml
+styles:
+  card:
+    - --button-card-ripple-icon-inset-padding: 0
+```
+
+Example to set icon shape to pill on a tall icon/image:
+
+```yaml
+styles:
+  card:
+    - '--button-card-ripple-icon-color': red
+    - '--button-card-ripple-icon-border-radius': 9999px
+    - '--button-card-ripple-icon-inset': 0% 20% 20% 20%
+```
+
 ## Installation
 
 ### Installation and tracking with `HACS`
@@ -1772,19 +1854,6 @@ styles:
           name: 1/1.5
           icon: mdi:lightbulb
           aspect_ratio: 1/1.5
-```
-
-### Changing the feedback color during a click
-
-For dark cards, it can be usefull to change the feedback color when clicking the button. The ripple effect uses a `mwc-ripple` element so you can style it with the CSS variables it supports.
-
-For example:
-
-```yaml
-styles:
-  card:
-    - --mdc-ripple-color: blue
-    - --mdc-ripple-press-opacity: 0.5
 ```
 
 ## Community guides

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   },
   "dependencies": {
     "@ctrl/tinycolor": "^3.1.6",
-    "@material/mwc-ripple": "^0.19.1",
     "fast-copy": "^2.1.0",
     "home-assistant-js-websocket": "^8.2.0",
     "lit": "^2.7.6",

--- a/src/action-handler.ts
+++ b/src/action-handler.ts
@@ -131,6 +131,10 @@ class ActionHandlerType extends HTMLElement implements ActionHandlerType {
     }
 
     element.actionHandler.start = (ev: Event) => {
+      // ignore is set when event is re-dispatched to allow ripples
+      if ((ev as any).detail?.ignore) {
+        return;
+      }
       this.cancelled = false;
       let x;
       let y;
@@ -164,6 +168,10 @@ class ActionHandlerType extends HTMLElement implements ActionHandlerType {
     };
 
     element.actionHandler.end = (ev: Event) => {
+      // ignore is set when event is re-dispatched to allow ripples
+      if ((ev as any).detail?.ignore) {
+        return;
+      }
       // Don't respond when moved or scrolled while touch
       if (['touchend', 'touchcancel'].includes(ev.type) && this.cancelled) {
         if (this.isRepeating && this.repeatTimeout) {

--- a/src/action-handler.ts
+++ b/src/action-handler.ts
@@ -1,7 +1,4 @@
 import { noChange } from 'lit-html';
-// import '@material/mwc-ripple';
-// tslint:disable-next-line
-import { Ripple } from '@material/mwc-ripple';
 import { fireEvent } from './common/fire-event';
 import { deepEqual } from './deep-equal';
 import { AttributePart, Directive, DirectiveParameters, directive } from 'lit-html/directive';
@@ -49,8 +46,6 @@ declare global {
 class ActionHandlerType extends HTMLElement implements ActionHandlerType {
   public holdTime = 500;
 
-  public ripple: Ripple;
-
   protected timer?: number;
 
   protected held = false;
@@ -65,23 +60,20 @@ class ActionHandlerType extends HTMLElement implements ActionHandlerType {
 
   private repeatCount = 0;
 
-  constructor() {
-    super();
-    this.ripple = document.createElement('mwc-ripple');
-  }
-
   public connectedCallback(): void {
     Object.assign(this.style, {
       position: 'fixed',
       width: isTouch ? '100px' : '50px',
       height: isTouch ? '100px' : '50px',
-      transform: 'translate(-50%, -50%)',
+      transform: 'translate(-50%, -50%) scale(0)',
       pointerEvents: 'none',
       zIndex: '999',
+      background: 'var(--primary-color)',
+      display: null,
+      opacity: '0.2',
+      borderRadius: '50%',
+      transition: 'transform 180ms ease-in-out',
     });
-
-    this.appendChild(this.ripple);
-    this.ripple.primary = true;
 
     ['touchcancel', 'mouseout', 'mouseup', 'touchmove', 'mousewheel', 'wheel', 'scroll'].forEach((ev) => {
       document.addEventListener(
@@ -249,21 +241,20 @@ class ActionHandlerType extends HTMLElement implements ActionHandlerType {
     element.addEventListener('keydown', element.actionHandler.handleKeyDown);
   }
 
-  private startAnimation(x: number, y: number): void {
+  private startAnimation(x: number, y: number) {
     Object.assign(this.style, {
       left: `${x}px`,
       top: `${y}px`,
-      display: null,
+      transform: 'translate(-50%, -50%) scale(1)',
     });
-    this.ripple.disabled = false;
-    this.ripple.startPress();
-    this.ripple.unbounded = true;
   }
 
-  private stopAnimation(): void {
-    this.ripple.endPress();
-    this.ripple.disabled = true;
-    this.style.display = 'none';
+  private stopAnimation() {
+    Object.assign(this.style, {
+      left: null,
+      top: null,
+      transform: 'translate(-50%, -50%) scale(0)',
+    });
   }
 }
 

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -1685,7 +1685,7 @@ class ButtonCard extends LitElement {
     const event = new CustomEvent(ev.type, ev);
     this.parentElement?.dispatchEvent(event);
     // Send non-bubbling event to ha-card to allow ripples
-    const rippleEvent = new CustomEvent(ev.type, { ...ev, bubbles: false, composed: false });
+    const rippleEvent = new CustomEvent(ev.type, { ...ev, bubbles: false, composed: false, detail: { ignore: true } });
     this._ripple.then((r) => {
       if (r) {
         r.parentElement?.dispatchEvent(rippleEvent);

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -1302,6 +1302,8 @@ class ButtonCard extends LitElement {
                   ?rotating=${this._rotate(configState)}
                   draggable="false"
                   @action=${this._hasIconActions ? this._handleIconAction : undefined}
+                  @pointerenter=${this._hasIconActions ? this._handleRippleIcon : undefined}
+                  @pointerleave=${this._hasIconActions ? this._handleRippleIcon : undefined}
                   @click=${this._hasIconActions ? this._sendToParent : undefined}
                   @touchstart=${this._hasIconActions ? this._sendToParent : undefined}
                   @mousedown=${this._hasIconActions ? this._sendToParent : undefined}

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -1,11 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { LitElement, html, TemplateResult, CSSResult, PropertyValues } from 'lit';
-import { customElement, property, queryAsync, eventOptions } from 'lit/decorators';
+import { customElement, property, queryAsync } from 'lit/decorators';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { until } from 'lit/directives/until.js';
-import { Ripple } from '@material/mwc-ripple';
-import { RippleHandlers } from '@material/mwc-ripple/ripple-handlers';
 import { styleMap, StyleInfo } from 'lit-html/directives/style-map';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html';
 import { classMap, ClassInfo } from 'lit-html/directives/class-map';
@@ -64,7 +62,7 @@ import {
 } from './common/const';
 import { handleAction } from './handle-action';
 import { fireEvent } from './common/fire-event';
-import { HomeAssistant } from './types/homeassistant';
+import { HaRipple, HomeAssistant } from './types/homeassistant';
 import { timerTimeRemaining } from './common/timer';
 import {
   formatDateTime,
@@ -126,7 +124,7 @@ class ButtonCard extends LitElement {
 
   @property({ type: Boolean, reflect: true }) preview = false;
 
-  @queryAsync('mwc-ripple') private _ripple!: Promise<Ripple | null>;
+  @queryAsync('ha-ripple') private _ripple!: Promise<HaRipple | null>;
 
   private _triggersAll?: boolean;
 
@@ -153,6 +151,8 @@ class ButtonCard extends LitElement {
   private _iconClickable = false;
 
   private _hasIconActions = false;
+
+  private _cardRipple = false;
 
   private get _doIHaveEverything(): boolean {
     return !!this._hass && !!this._config && this.isConnected;
@@ -985,9 +985,11 @@ class ButtonCard extends LitElement {
       this._hasChildCards(this._config!.custom_fields) ||
       !!(configState && this._hasChildCards(configState.custom_fields));
 
-    this._cardClickable = tap_action != 'none' || hold_action != 'none' || double_tap_action != 'none' || hasChildCards;
+    const cardHasActions = tap_action != 'none' || hold_action != 'none' || double_tap_action != 'none';
+    this._cardClickable = cardHasActions || hasChildCards;
     this._hasIconActions = icon_tap_action != 'none' || icon_hold_action != 'none' || icon_double_tap_action != 'none';
     this._iconClickable = this._cardClickable || this._hasIconActions;
+    this._cardRipple = cardHasActions || this._hasIconActions;
   }
 
   private _rotate(configState: StateConfig | undefined): boolean {
@@ -1080,6 +1082,7 @@ class ButtonCard extends LitElement {
       '--button-card-light-color-no-temperature',
       this._getColorForLightEntity(this._stateObj, false),
     );
+    this.style.setProperty('--button-card-ripple-color', buttonColor);
     lockStyle = { ...lockStyle, ...lockStyleFromConfig };
 
     const extraStyles = this._config!.extra_styles
@@ -1097,13 +1100,6 @@ class ButtonCard extends LitElement {
           class=${classMap(classList)}
           style=${styleMap(cardStyle)}
           @action=${this._handleAction}
-          @focus="${this.handleRippleFocus}"
-          @blur="${this.handleRippleBlur}"
-          @mousedown="${this.handleRippleActivate}"
-          @mouseup="${this.handleRippleDeactivate}"
-          @touchstart="${this.handleRippleActivate}"
-          @touchend="${this.handleRippleDeactivate}"
-          @touchcancel="${this.handleRippleDeactivate}"
           .actionHandler=${actionHandler({
             hasDoubleClick: this._config!.double_tap_action!.action !== 'none',
             hasHold: this._config!.hold_action!.action !== 'none',
@@ -1113,7 +1109,7 @@ class ButtonCard extends LitElement {
           .config="${this._config}"
         >
           ${this._buttonContent(this._stateObj, configState, buttonColor)}
-          <mwc-ripple id="ripple"></mwc-ripple>
+          <ha-ripple .disabled=${!this._cardRipple}></ha-ripple>
         </ha-card>
         ${this._getLock(lockStyle)}
       </div>
@@ -1276,6 +1272,8 @@ class ButtonCard extends LitElement {
                   id="icon"
                   ?rotating=${this._rotate(configState)}
                   @action=${this._hasIconActions ? this._handleIconAction : undefined}
+                  @pointerenter=${this._hasIconActions ? this._handleRippleIcon : undefined}
+                  @pointerleave=${this._hasIconActions ? this._handleRippleIcon : undefined}
                   @click=${this._hasIconActions ? this._sendToParent : undefined}
                   @touchstart=${this._hasIconActions ? this._sendToParent : undefined}
                   @mousedown=${this._hasIconActions ? this._sendToParent : undefined}
@@ -1536,27 +1534,16 @@ class ButtonCard extends LitElement {
     return configDuplicate;
   }
 
-  private _rippleHandlers: RippleHandlers = new RippleHandlers(() => {
-    // this._shouldRenderRipple = true;
-    return this._ripple;
-  });
-
-  // backward compatibility
-  @eventOptions({ passive: true })
-  private handleRippleActivate(evt?: Event): void {
-    this._ripple.then((r) => r && typeof r.startPress === 'function' && this._rippleHandlers.startPress(evt));
-  }
-
-  private handleRippleDeactivate(): void {
-    this._ripple.then((r) => r && typeof r.endPress === 'function' && this._rippleHandlers.endPress());
-  }
-
-  private handleRippleFocus(): void {
-    this._ripple.then((r) => r && typeof r.startFocus === 'function' && this._rippleHandlers.startFocus());
-  }
-
-  private handleRippleBlur(): void {
-    this._ripple.then((r) => r && typeof r.endFocus === 'function' && this._rippleHandlers.endFocus());
+  private _handleRippleIcon(ev: PointerEvent): void {
+    this._ripple.then((r) => {
+      if (r) {
+        if (ev.type === 'pointerenter') {
+          r.setAttribute('icon', '');
+        } else if (ev.type === 'pointerleave') {
+          r.removeAttribute('icon');
+        }
+      }
+    });
   }
 
   private _handleIconAction(ev: any): void {

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -1661,5 +1661,12 @@ class ButtonCard extends LitElement {
     ev.stopPropagation();
     const event = new CustomEvent(ev.type, ev);
     this.parentElement?.dispatchEvent(event);
+    // Send non-bubbling event to ha-card to allow ripples
+    const rippleEvent = new CustomEvent(ev.type, { ...ev, bubbles: false, composed: false });
+    this._ripple.then((r) => {
+      if (r) {
+        r.parentElement?.dispatchEvent(rippleEvent);
+      }
+    });
   }
 }

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -1538,9 +1538,30 @@ class ButtonCard extends LitElement {
     this._ripple.then((r) => {
       if (r) {
         if (ev.type === 'pointerenter') {
+          const iconRect = (ev.target as HTMLElement)?.getBoundingClientRect() ?? null;
+          const cardRect = r.getBoundingClientRect();
+          const iconInset = { top: 0, left: 0, bottom: 0, right: 0 };
+          const iconComputedStyle = ev.target ? getComputedStyle(ev.target as HTMLElement) : null;
+          const iconInsetPadding = iconComputedStyle
+            ? parseInt(iconComputedStyle.getPropertyValue('--button-card-ripple-icon-inset-padding'))
+            : 12;
+          let insetStyle = '';
+          if (iconRect && cardRect) {
+            iconInset.top = iconRect.top - cardRect.top - iconInsetPadding;
+            iconInset.top = iconInset.top < 0 ? 0 : iconInset.top;
+            iconInset.left = iconRect.left - cardRect.left - iconInsetPadding;
+            iconInset.left = iconInset.left < 0 ? 0 : iconInset.left;
+            iconInset.bottom = cardRect.bottom - iconRect.bottom - iconInsetPadding;
+            iconInset.bottom = iconInset.bottom < 0 ? 0 : iconInset.bottom;
+            iconInset.right = cardRect.right - iconRect.right - iconInsetPadding;
+            iconInset.right = iconInset.right < 0 ? 0 : iconInset.right;
+            insetStyle = `${iconInset.top}px ${iconInset.right}px ${iconInset.bottom}px ${iconInset.left}px`;
+          }
           r.setAttribute('icon', '');
+          insetStyle != '' && r.style.setProperty('--dynamic-ripple-icon-inset', insetStyle);
         } else if (ev.type === 'pointerleave') {
           r.removeAttribute('icon');
+          r.style.removeProperty('--dynamic-ripple-icon-inset');
         }
       }
     });

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -23,6 +23,14 @@ export const styles = css`
     line-height: normal;
 
     --ha-ripple-color: var(--mdc-ripple-color, var(--button-card-ripple-color));
+    --ha-ripple-hover-color: var(
+      --mdc-ripple-hover-color,
+      var(--ha-ripple-color, var(--button-card-ripple-hover-color))
+    );
+    --ha-ripple-pressed-color: var(
+      --mdc-ripple-press-color,
+      var(--ha-ripple-color, var(--button-card-ripple-pressed-color))
+    );
     --ha-ripple-hover-opacity: var(--mdc-ripple-hover-opacity, var(--button-card-ripple-hover-opacity, 0.08));
     --ha-ripple-pressed-opacity: var(--mdc-ripple-press-opacity, var(--button-card-ripple-pressed-opacity, 0.12));
 
@@ -44,25 +52,16 @@ export const styles = css`
   ha-ripple[icon] {
     inset: var(--button-card-ripple-icon-inset, 5px);
     border-radius: var(--button-card-ripple-icon-border-radius, 9999px);
-    --md-ripple-color: var(
-      --mdc-ripple-color,
-      var(--button-card-ripple-icon-color, var(--button-card-ripple-color, var(--ha-ripple-color)))
-    );
+    --md-ripple-color: var(--button-card-ripple-icon-color, var(--ha-ripple-color));
+    --md-ripple-hover-color: var(--button-card-ripple-icon-color, var(--ha-ripple-hover-color));
+    --md-ripple-pressed-color: var(--button-card-ripple-pressed-color, var(--ha-ripple-pressed-color));
     --md-ripple-hover-opacity: var(
       --button-card-ripple-icon-hover-opacity,
-      calc(
-        var(--mdc-ripple-hover-opacity, var(--button-card-ripple-hover-opacity, var(--ha-ripple-hover-opacity, 0.08))) +
-          0.05
-      )
+      calc(var(--mdc-ripple-hover-opacity, var(--ha-ripple-hover-opacity, 0.08)) + 0.05)
     );
     --md-ripple-pressed-opacity: var(
       --button-card-ripple-icon-pressed-opacity,
-      calc(
-        var(
-            --mdc-ripple-press-opacity,
-            var(--button-card-ripple-pressed-opacity, var(--ha-ripple-pressed-opacity, 0.12))
-          ) + 0.05
-      )
+      calc(var(--mdc-ripple-press-opacity, var(--ha-ripple-pressed-opacity, 0.12)) + 0.05)
     );
   }
   :host(.tooltip) .tooltiptext {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -23,17 +23,11 @@ export const styles = css`
     align-items: center;
     line-height: normal;
 
-    --ha-ripple-color: var(--mdc-ripple-color, var(--button-card-ripple-color));
-    --ha-ripple-hover-color: var(
-      --mdc-ripple-hover-color,
-      var(--ha-ripple-color, var(--button-card-ripple-hover-color))
-    );
-    --ha-ripple-pressed-color: var(
-      --mdc-ripple-press-color,
-      var(--ha-ripple-color, var(--button-card-ripple-pressed-color))
-    );
-    --ha-ripple-hover-opacity: var(--mdc-ripple-hover-opacity, var(--button-card-ripple-hover-opacity, 0.08));
-    --ha-ripple-pressed-opacity: var(--mdc-ripple-press-opacity, var(--button-card-ripple-pressed-opacity, 0.12));
+    --ha-ripple-color: var(--button-card-ripple-color);
+    --ha-ripple-hover-color: var(--ha-ripple-color, var(--button-card-ripple-hover-color));
+    --ha-ripple-pressed-color: var(--ha-ripple-color, var(--button-card-ripple-pressed-color));
+    --ha-ripple-hover-opacity: var(--button-card-ripple-hover-opacity, 0.08);
+    --ha-ripple-pressed-opacity: var(--button-card-ripple-pressed-opacity, 0.12);
 
     -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */
@@ -58,11 +52,11 @@ export const styles = css`
     --md-ripple-pressed-color: var(--button-card-ripple-pressed-color, var(--ha-ripple-pressed-color));
     --md-ripple-hover-opacity: var(
       --button-card-ripple-icon-hover-opacity,
-      calc(var(--mdc-ripple-hover-opacity, var(--ha-ripple-hover-opacity, 0.08)) + 0.05)
+      calc(var(--ha-ripple-hover-opacity, 0.08) + 0.05)
     );
     --md-ripple-pressed-opacity: var(
       --button-card-ripple-icon-pressed-opacity,
-      calc(var(--mdc-ripple-press-opacity, var(--ha-ripple-pressed-opacity, 0.12)) + 0.05)
+      calc(var(--ha-ripple-pressed-opacity, 0.12) + 0.05)
     );
   }
   :host(.tooltip) .tooltiptext {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -24,7 +24,7 @@ export const styles = css`
 
     --ha-ripple-color: var(--mdc-ripple-color, var(--button-card-ripple-color));
     --ha-ripple-hover-opacity: var(--mdc-ripple-hover-opacity, var(--button-card-ripple-hover-opacity, 0.08));
-    --ha-ripple-pressed-opacity: var(--mdc-ripple-pressed-opacity, var(--button-card-ripple-pressed-opacity, 0.12));
+    --ha-ripple-pressed-opacity: var(--mdc-ripple-press-opacity, var(--button-card-ripple-pressed-opacity, 0.12));
 
     -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */
@@ -46,11 +46,11 @@ export const styles = css`
     border-radius: var(--button-card-ripple-icon-border-radius, 9999px);
     --ha-ripple-hover-opacity: var(
       --button-card-ripple-icon-hover-opacity,
-      calc(var(--button-card-ripple-hover-opacity, 0.08) + 0.05)
+      calc(var(--mdc-ripple-hover-opacity, var(--button-card-ripple-hover-opacity, 0.08)) + 0.05)
     );
     --ha-ripple-pressed-opacity: var(
       --button-card-ripple-icon-pressed-opacity,
-      calc(var(--button-card--ripple-pressed-opacity, 0.12) + 0.05)
+      calc(var(--mdc-ripple-press-opacity, var(--button-card-ripple-pressed-opacity, 0.12)) + 0.05)
     );
   }
   :host(.tooltip) .tooltiptext {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -44,6 +44,7 @@ export const styles = css`
   ha-ripple[icon] {
     inset: var(--button-card-ripple-icon-inset, 5px);
     border-radius: var(--button-card-ripple-icon-border-radius, 9999px);
+    --ha-ripple-color: var(--mdc-ripple-color, var(--button-card-ripple-icon-color, var(--button-card-ripple-color)));
     --ha-ripple-hover-opacity: var(
       --button-card-ripple-icon-hover-opacity,
       calc(var(--mdc-ripple-hover-opacity, var(--button-card-ripple-hover-opacity, 0.08)) + 0.05)

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -23,8 +23,8 @@ export const styles = css`
     line-height: normal;
 
     --ha-ripple-color: var(--mdc-ripple-color, var(--button-card-ripple-color));
-    --ha-ripple-hover-opacity: var(--mdc-ripple-hover-opacity, var(--ha-ripple-hover-opacity, 0.08));
-    --ha-ripple-pressed-opacity: var(--mdc-ripple-pressed-opacity, var(--ha-ripple-pressed-opacity, 0.12));
+    --ha-ripple-hover-opacity: var(--mdc-ripple-hover-opacity, var(--button-card-ripple-hover-opacity, 0.08));
+    --ha-ripple-pressed-opacity: var(--mdc-ripple-pressed-opacity, var(--button-card-ripple-pressed-opacity, 0.12));
 
     -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */
@@ -44,8 +44,14 @@ export const styles = css`
   ha-ripple[icon] {
     inset: var(--button-card-ripple-icon-inset, 5px);
     border-radius: var(--button-card-ripple-icon-border-radius, 9999px);
-    --ha-hover-opacity: calc(var(--ha-ripple-hover-opacity, 0.08) + 0.03);
-    --ha-pressed-opacity: calc(var(--ha-ripple-pressed-opacity, 0.12) + 0.05);
+    --ha-ripple-hover-opacity: var(
+      --button-card-ripple-icon-hover-opacity,
+      calc(var(--button-card-ripple-hover-opacity, 0.08) + 0.05)
+    );
+    --ha-ripple-pressed-opacity: var(
+      --button-card-ripple-icon-pressed-opacity,
+      calc(var(--button-card--ripple-pressed-opacity, 0.12) + 0.05)
+    );
   }
   :host(.tooltip) .tooltiptext {
     pointer-events: none;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -44,14 +44,25 @@ export const styles = css`
   ha-ripple[icon] {
     inset: var(--button-card-ripple-icon-inset, 5px);
     border-radius: var(--button-card-ripple-icon-border-radius, 9999px);
-    --ha-ripple-color: var(--mdc-ripple-color, var(--button-card-ripple-icon-color, var(--button-card-ripple-color)));
-    --ha-ripple-hover-opacity: var(
-      --button-card-ripple-icon-hover-opacity,
-      calc(var(--mdc-ripple-hover-opacity, var(--button-card-ripple-hover-opacity, 0.08)) + 0.05)
+    --md-ripple-color: var(
+      --mdc-ripple-color,
+      var(--button-card-ripple-icon-color, var(--button-card-ripple-color, var(--ha-ripple-color)))
     );
-    --ha-ripple-pressed-opacity: var(
+    --md-ripple-hover-opacity: var(
+      --button-card-ripple-icon-hover-opacity,
+      calc(
+        var(--mdc-ripple-hover-opacity, var(--button-card-ripple-hover-opacity, var(--ha-ripple-hover-opacity, 0.08))) +
+          0.05
+      )
+    );
+    --md-ripple-pressed-opacity: var(
       --button-card-ripple-icon-pressed-opacity,
-      calc(var(--mdc-ripple-press-opacity, var(--button-card-ripple-pressed-opacity, 0.12)) + 0.05)
+      calc(
+        var(
+            --mdc-ripple-press-opacity,
+            var(--button-card-ripple-pressed-opacity, var(--ha-ripple-pressed-opacity, 0.12))
+          ) + 0.05
+      )
     );
   }
   :host(.tooltip) .tooltiptext {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -22,6 +22,10 @@ export const styles = css`
     align-items: center;
     line-height: normal;
 
+    --ha-ripple-color: var(--mdc-ripple-color, var(--button-card-ripple-color));
+    --ha-ripple-hover-opacity: var(--mdc-ripple-hover-opacity, var(--ha-ripple-hover-opacity, 0.08));
+    --ha-ripple-pressed-opacity: var(--mdc-ripple-pressed-opacity, var(--ha-ripple-pressed-opacity, 0.12));
+
     -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */
     -khtml-user-select: none; /* Konqueror HTML */
@@ -36,6 +40,12 @@ export const styles = css`
   }
   ha-card.section {
     height: 100%;
+  }
+  ha-ripple[icon] {
+    inset: var(--button-card-ripple-icon-inset, 5px);
+    border-radius: var(--button-card-ripple-icon-border-radius, 9999px);
+    --ha-hover-opacity: calc(var(--ha-ripple-hover-opacity, 0.08) + 0.03);
+    --ha-pressed-opacity: calc(var(--ha-ripple-pressed-opacity, 0.12) + 0.05);
   }
   :host(.tooltip) .tooltiptext {
     pointer-events: none;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -5,6 +5,7 @@ export const styles = css`
     position: relative;
     display: block;
     --state-inactive-color: var(--state-icon-color);
+    --button-card-ripple-icon-inset-padding: 12px;
   }
 
   :host(.section) {
@@ -50,8 +51,8 @@ export const styles = css`
     height: 100%;
   }
   ha-ripple[icon] {
-    inset: var(--button-card-ripple-icon-inset, 5px);
-    border-radius: var(--button-card-ripple-icon-border-radius, 9999px);
+    inset: var(--button-card-ripple-icon-inset, var(--dynamic-ripple-icon-inset, 5px));
+    border-radius: var(--button-card-ripple-icon-border-radius, var(--ha-card-border-radius, 12px));
     --md-ripple-color: var(--button-card-ripple-icon-color, var(--ha-ripple-color));
     --md-ripple-hover-color: var(--button-card-ripple-icon-color, var(--ha-ripple-hover-color));
     --md-ripple-pressed-color: var(--button-card-ripple-pressed-color, var(--ha-ripple-pressed-color));

--- a/src/types/homeassistant.ts
+++ b/src/types/homeassistant.ts
@@ -7,6 +7,7 @@ import {
   HassServices,
   MessageBase,
 } from 'home-assistant-js-websocket';
+import { LitElement } from 'lit';
 
 export interface EntityRegistryDisplayEntry {
   entity_id: string;
@@ -280,4 +281,8 @@ export interface Themes {
 export interface ResolvedMediaSource {
   url: string;
   mime_type: string;
+}
+
+export interface HaRipple extends LitElement {
+  disabled: boolean;
 }

--- a/test/ui-lovelace.yaml
+++ b/test/ui-lovelace.yaml
@@ -2343,6 +2343,58 @@ views:
         cards:
           - type: 'custom:button-card'
             color_type: label-card
+            name: Test ripple override (ha)
+            styles:
+              card:
+                - font-weight: bold
+                - text-transform: uppercase
+            section_mode: true
+            grid_options:
+              rows: 1
+              columns: 12
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Color
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --ha-ripple-color: red
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Opacity
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --ha-ripple-hover-opacity: 0.3
+                - --ha-ripple-press-opacity: 0.6
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Color & opacity
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --ha-ripple-hover-opacity: 0.3
+                - --ha-ripple-press-opacity: 0.6
+                - --ha-ripple-color: red
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+      - type: grid
+        cards:
+          - type: 'custom:button-card'
+            color_type: label-card
             name: Test ripple override (button-card)
             styles:
               card:

--- a/test/ui-lovelace.yaml
+++ b/test/ui-lovelace.yaml
@@ -2470,7 +2470,7 @@ views:
               columns: 4
           - type: 'custom:button-card'
             entity: switch.skylight
-            name: Color & opacity
+            name: Icon color & opacity
             icon_tap_action:
               action: toggle
             styles:

--- a/test/ui-lovelace.yaml
+++ b/test/ui-lovelace.yaml
@@ -552,12 +552,16 @@ views:
                     name: icon_name_state_no_state
                     show_state: false
                     layout: icon_name_state
+                    icon_tap_action:
+                      action: more-info
 
               - type: 'custom:button-card'
                 entity: sensor.sensor1
                 name: icon_name_state
                 show_state: true
                 layout: icon_name_state
+                icon_tap_action:
+                  action: more-info
               - type: 'custom:button-card'
                 color_type: label-card
                 name: Testing default size
@@ -574,10 +578,14 @@ views:
                     show_state: false
                     show_name: false
                     layout: icon_name_state
+                    icon_tap_action:
+                      action: more-info
                   - type: 'custom:button-card'
                     entity: sensor.sensor1
                     show_name: false
                     show_state: false
+                    tap_action:
+                      action: more-info
               - type: horizontal-stack
                 cards:
                   - type: 'custom:button-card'
@@ -585,6 +593,8 @@ views:
                     name: icon_name
                     layout: icon_name
                     show_state: true
+                    icon_tap_action:
+                      action: more-info
                   - type: 'custom:button-card'
                     entity: sensor.sensor1
                     name: icon_state
@@ -592,18 +602,24 @@ views:
                     show_state: true
                     show_name: true
                     color_type: card
+                    icon_tap_action:
+                      action: more-info
               - type: horizontal-stack
                 cards:
                   - type: 'custom:button-card'
                     entity: sensor.sensor1
                     name: icon_name
                     layout: icon_name
+                    icon_tap_action:
+                      action: more-info
                   - type: 'custom:button-card'
                     entity: sensor.sensor1
                     name: icon_state
                     layout: icon_state
                     show_state: true
                     show_name: false
+                    icon_tap_action:
+                      action: more-info
                   - type: 'custom:button-card'
                     entity: sensor.sensor1
                     color_type: card
@@ -612,6 +628,8 @@ views:
                     show_state: true
                     show_name: false
                     show_units: false
+                    icon_tap_action:
+                      action: more-info
               - type: horizontal-stack
                 cards:
                   - type: 'custom:button-card'
@@ -619,11 +637,15 @@ views:
                     layout: icon_name_state2nd
                     show_state: true
                     show_name: true
+                    icon_tap_action:
+                      action: more-info
                   - type: 'custom:button-card'
                     entity: sensor.sensor1
                     layout: icon_state_name2nd
                     show_state: true
                     show_name: true
+                    icon_tap_action:
+                      action: more-info
 
               - type: horizontal-stack
                 cards:
@@ -632,6 +654,8 @@ views:
                     name: name_state
                     layout: name_state
                     show_state: true
+                    icon_tap_action:
+                      action: more-info
                   - type: 'custom:button-card'
                     entity: sensor.sensor1
                     name: default state
@@ -639,11 +663,15 @@ views:
                     units: UNITS TOO LONNNNNNG
                     color_type: card
                     show_name: false
+                    icon_tap_action:
+                      action: more-info
                   - type: 'custom:button-card'
                     entity: sensor.sensor1
                     name: default name
                     show_state: false
                     show_name: true
+                    icon_tap_action:
+                      action: more-info
 
       - type: vertical-stack
         cards:
@@ -2490,7 +2518,6 @@ views:
             styles:
               card:
                 - --button-card-ripple-icon-inset: 0
-                - --button-card-ripple-icon-border-radius: var(--ha-card-border-radius, 12px)
                 - --button-card-ripple-icon-color: red
             section_mode: true
             grid_options:
@@ -2498,13 +2525,24 @@ views:
               columns: 4
           - type: 'custom:button-card'
             entity: switch.skylight
-            name: Inset narrow
+            name: Inset minimal (5px)
             icon_tap_action:
               action: toggle
             styles:
               card:
-                - --button-card-ripple-icon-inset: 1em
-                - --button-card-ripple-icon-border-radius: var(--ha-card-border-radius, 12px)
+                - --button-card-ripple-icon-inset: 5px
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Inset 0 padding
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --button-card-ripple-icon-inset-padding: 0
             section_mode: true
             grid_options:
               rows: 2
@@ -3010,7 +3048,8 @@ views:
                 entity: sensor.sensor1
                 show_state: true
                 layout: icon_name_state
-
+                icon_tap_action:
+                  action: more-info
           - type: horizontal-stack
             cards:
               - type: 'custom:button-card'
@@ -3035,9 +3074,13 @@ views:
                 entity: sensor.sensor1
                 show_state: true
                 layout: name_state
+                icon_tap_action:
+                  action: more-info
               - type: 'custom:button-card'
                 entity: sensor.sensor1
                 show_state: true
+                icon_tap_action:
+                  action: more-info
 
           - type: horizontal-stack
             cards:
@@ -3063,10 +3106,14 @@ views:
                 entity: sensor.sensor1
                 show_state: true
                 layout: icon_name
+                icon_tap_action:
+                  action: more-info
               - type: 'custom:button-card'
                 entity: sensor.sensor1
                 show_state: true
                 layout: icon_state
+                icon_tap_action:
+                  action: more-info
 
           - type: horizontal-stack
             cards:
@@ -3092,11 +3139,15 @@ views:
                 entity: sensor.sensor1
                 show_state: false
                 layout: icon_name
+                icon_tap_action:
+                  action: more-info
               - type: 'custom:button-card'
                 entity: sensor.sensor1
                 show_state: true
                 show_name: false
                 layout: icon_state
+                icon_tap_action:
+                  action: more-info
 
           - type: horizontal-stack
             cards:
@@ -3122,10 +3173,14 @@ views:
                 entity: sensor.sensor1
                 show_state: true
                 layout: icon_name_state2nd
+                icon_tap_action:
+                  action: more-info
               - type: 'custom:button-card'
                 entity: sensor.sensor1
                 show_state: true
                 layout: icon_state_name2nd
+                icon_tap_action:
+                  action: more-info
 
       - type: vertical-stack
         cards:

--- a/test/ui-lovelace.yaml
+++ b/test/ui-lovelace.yaml
@@ -1890,7 +1890,7 @@ views:
               columns: 12
           - type: 'custom:button-card'
             entity: switch.skylight
-            name: icon dbl more-info
+            name: icon more-info
             tap_action:
               action: none
             icon_tap_action:
@@ -1901,7 +1901,7 @@ views:
               columns: 4
           - type: 'custom:button-card'
             entity: switch.skylight
-            name: icon dbl navigate
+            name: icon navigate
             tap_action:
               action: none
             icon_tap_action:
@@ -1913,7 +1913,7 @@ views:
               columns: 4
           - type: 'custom:button-card'
             entity: switch.skylight
-            name: icon dbl service
+            name: icon service
             tap_action:
               action: none
             icon_tap_action:
@@ -1954,6 +1954,505 @@ views:
               service: input_number.increment
               target:
                 entity_id: input_number.test
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+
+  - title: Ripples
+    type: sections
+    sections:
+      - type: grid
+        cards:
+          - type: 'custom:button-card'
+            color_type: label-card
+            name: Test standard ripple
+            styles:
+              card:
+                - font-weight: bold
+                - text-transform: uppercase
+            section_mode: true
+            grid_options:
+              rows: 1
+              columns: 12
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: No action
+            tap_action:
+              action: none
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Tap action
+            tap_action:
+              action: toggle
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Dbl tap action
+            tap_action:
+              action: none
+            double_tap_action:
+              action: toggle
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Hold action
+            hold_action:
+              action: more-info
+              entity: switch.skylight
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Hold repeat action
+            hold_action:
+              action: call-service
+              repeat: 500
+              repeat_limit: 2
+              service: input_number.increment
+              service_data:
+                entity_id: input_number.test
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: custom:button-card
+            entity: input_number.test
+            show_label: true
+            show_icon: false
+            label: |
+              [[[
+                return entity.state;
+              ]]]
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+      - type: grid
+        cards:
+          - type: 'custom:button-card'
+            color_type: label-card
+            name: Test icon ripple
+            styles:
+              card:
+                - font-weight: bold
+                - text-transform: uppercase
+            section_mode: true
+            grid_options:
+              rows: 1
+              columns: 12
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: No action
+            tap_action:
+              action: none
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Icon tap action
+            tap_action:
+              action: none
+            icon_tap_action:
+              action: toggle
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Icon dbl tap action
+            tap_action:
+              action: none
+            icon_double_tap_action:
+              action: toggle
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Icon hold action
+            tap_action:
+              action: none
+            icon_tap_action:
+              action: toggle
+            icon_hold_action:
+              action: more-info
+              entity: switch.skylight
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Icon hold repeat action
+            tap_action:
+              action: none
+            icon_tap_action:
+              action: toggle
+            icon_hold_action:
+              action: call-service
+              repeat: 500
+              repeat_limit: 2
+              service: input_number.increment
+              service_data:
+                entity_id: input_number.test
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: custom:button-card
+            entity: input_number.test
+            show_label: true
+            show_icon: false
+            label: |
+              [[[
+                return entity.state;
+              ]]]
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+      - type: grid
+        cards:
+          - type: 'custom:button-card'
+            color_type: label-card
+            name: Test both ripple
+            styles:
+              card:
+                - font-weight: bold
+                - text-transform: uppercase
+            section_mode: true
+            grid_options:
+              rows: 1
+              columns: 12
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: No action
+            tap_action:
+              action: none
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Tap actions
+            tap_action:
+              action: toggle
+            icon_tap_action:
+              action: toggle
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Dbl tap actions
+            tap_action:
+              action: none
+            double_tap_action:
+              action: toggle
+            icon_double_tap_action:
+              action: toggle
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Hold actions
+            tap_action:
+              action: none
+            hold_action:
+              action: toggle
+            icon_hold_action:
+              action: more-info
+              entity: switch.skylight
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Hold repeat actions
+            tap_action:
+              action: none
+            hold_action:
+              action: call-service
+              repeat: 500
+              repeat_limit: 2
+              service: switch.toggle
+              service_data:
+                entity_id: switch.skylight
+            icon_hold_action:
+              action: call-service
+              repeat: 500
+              repeat_limit: 2
+              service: input_number.increment
+              service_data:
+                entity_id: input_number.test
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: custom:button-card
+            entity: input_number.test
+            show_label: true
+            show_icon: false
+            label: |
+              [[[
+                return entity.state;
+              ]]]
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+      - type: grid
+        cards:
+          - type: 'custom:button-card'
+            color_type: label-card
+            name: Test color ripple
+            styles:
+              card:
+                - font-weight: bold
+                - text-transform: uppercase
+            section_mode: true
+            grid_options:
+              rows: 1
+              columns: 12
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Color icon
+            icon_tap_action:
+              action: toggle
+            color_type: icon
+            color: red
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Color card
+            icon_tap_action:
+              action: toggle
+            color_type: card
+            color: purple
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: light.living_room_rgbww_lights
+            name: Light std css
+            icon_tap_action:
+              action: toggle
+            hold_action:
+              action: more-info
+              entity: light.living_room_rgbww_lights
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: light.living_room_rgbww_lights
+            name: Light colored
+            icon_tap_action:
+              action: toggle
+            hold_action:
+              action: more-info
+              entity: light.living_room_rgbww_lights
+            styles:
+              icon:
+                - color: var(--button-card-light-color)
+              card:
+                - --button-card-ripple-color: var(--button-card-light-color)
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+      - type: grid
+        cards:
+          - type: 'custom:button-card'
+            color_type: label-card
+            name: Test ripple override (mdc)
+            styles:
+              card:
+                - font-weight: bold
+                - text-transform: uppercase
+            section_mode: true
+            grid_options:
+              rows: 1
+              columns: 12
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Color
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --mdc-ripple-color: red
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Opacity
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --mdc-ripple-hover-opacity: 0.3
+                - --mdc-ripple-press-opacity: 0.6
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Color & opacity
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --mdc-ripple-hover-opacity: 0.3
+                - --mdc-ripple-press-opacity: 0.6
+                - --mdc-ripple-color: red
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+      - type: grid
+        cards:
+          - type: 'custom:button-card'
+            color_type: label-card
+            name: Test ripple override (button-card)
+            styles:
+              card:
+                - font-weight: bold
+                - text-transform: uppercase
+            section_mode: true
+            grid_options:
+              rows: 1
+              columns: 12
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Color
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --button-card-ripple-color: red
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Opacity
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --button-card-ripple-hover-opacity: 0.3
+                - --button-card-ripple-press-opacity: 0.6
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Color & opacity
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --button-card-ripple-hover-opacity: 0.3
+                - --button-card-ripple-press-opacity: 0.6
+                - --button-card-ripple-color: red
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Icon color
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --button-card-ripple-icon-color: red
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Icon opacity
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --button-card-ripple-icon-hover-opacity: 0.3
+                - --button-card-ripple-icon-press-opacity: 0.6
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Color & opacity
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --button-card-ripple-icon-hover-opacity: 0.3
+                - --button-card-ripple-icon-press-opacity: 0.6
+                - --button-card-ripple-icon-color: red
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Inset 0 & color
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --button-card-ripple-icon-inset: 0
+                - --button-card-ripple-icon-border-radius: var(--ha-card-border-radius, 12px)
+                - --button-card-ripple-icon-color: red
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: Inset narrow
+            icon_tap_action:
+              action: toggle
+            styles:
+              card:
+                - --button-card-ripple-icon-inset: 1em
+                - --button-card-ripple-icon-border-radius: var(--ha-card-border-radius, 12px)
             section_mode: true
             grid_options:
               rows: 2

--- a/yarn.lock
+++ b/yarn.lock
@@ -431,74 +431,6 @@
   dependencies:
     "@lit-labs/ssr-dom-shim" "^1.0.0"
 
-"@material/animation@8.0.0-canary.774dcfc8e.0":
-  version "8.0.0-canary.774dcfc8e.0"
-  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-8.0.0-canary.774dcfc8e.0.tgz#26b4c4d804397a2350e9eee72cddcc0bb5dcb6a8"
-  integrity sha512-h8pGWQy5mZ7yNveKGSwxP1pRV9wGs6hjXiOR5nS0NePjfIgRsqUBnSwNKW5TcP/ThPtnATbq0FfARs+ugHdFqA==
-  dependencies:
-    tslib "^1.9.3"
-
-"@material/base@8.0.0-canary.774dcfc8e.0", "@material/base@=8.0.0-canary.774dcfc8e.0":
-  version "8.0.0-canary.774dcfc8e.0"
-  resolved "https://registry.yarnpkg.com/@material/base/-/base-8.0.0-canary.774dcfc8e.0.tgz#be9e8ff6e8e366d74a6b2adea8edc7ee84b952b2"
-  integrity sha512-638e0T0WUlsAW21hgFhMNN/MnCErKmuovzJjA/vwrhPRHKtxrIuTIkmX2G1yQ7LlNQWhKG7W32g9KNd06+PNGA==
-  dependencies:
-    tslib "^1.9.3"
-
-"@material/dom@8.0.0-canary.774dcfc8e.0", "@material/dom@=8.0.0-canary.774dcfc8e.0":
-  version "8.0.0-canary.774dcfc8e.0"
-  resolved "https://registry.yarnpkg.com/@material/dom/-/dom-8.0.0-canary.774dcfc8e.0.tgz#b5d52f40e1a9965bb5b6fe8e7a50eb96a29af1ba"
-  integrity sha512-SHrc5zNOoWR2b9nShcv/A2D2C67beBdCS/KDPzezCpi0UfJYZVcjf9EmYDpNhZHh9jil3BiDvldknHazLGkqWA==
-  dependencies:
-    "@material/feature-targeting" "8.0.0-canary.774dcfc8e.0"
-    tslib "^1.9.3"
-
-"@material/feature-targeting@8.0.0-canary.774dcfc8e.0":
-  version "8.0.0-canary.774dcfc8e.0"
-  resolved "https://registry.yarnpkg.com/@material/feature-targeting/-/feature-targeting-8.0.0-canary.774dcfc8e.0.tgz#417361ead5031e6bbd72b6ac2e85b786829ff6e1"
-  integrity sha512-XcCJOCZbk2kg41dTIvWd1iEJzl4rtGJ6ZK4o/FWQbczDJUcKN35je0+d/a/DvEh22t2Tj9M96n8HmTkS447Rhw==
-
-"@material/mwc-base@^0.19.1":
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-base/-/mwc-base-0.19.1.tgz#0b4069249f90e3971467c6ed8d26bb6be219bd30"
-  integrity sha512-tYih18Fd99nURPN8ulzibIUeCUo/Wv1ScQIWYZtDkXwOiEvDJDYm0jDO96bOMRZK8aIvW/URspbUoa/RkK2yYw==
-  dependencies:
-    "@material/base" "=8.0.0-canary.774dcfc8e.0"
-    "@material/dom" "=8.0.0-canary.774dcfc8e.0"
-    lit-element "^2.3.0"
-    tslib "^1.10.0"
-
-"@material/mwc-ripple@^0.19.1":
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/@material/mwc-ripple/-/mwc-ripple-0.19.1.tgz#b40a4668cc2a0029a3e8f3a81e8f80d76a754f92"
-  integrity sha512-nrT7tNMsDV2Qx0dyYfFAQy5Rwogtip4UCX2CpHL4A5o9Ba1XHiEqy/CRZmijjxTK6FO1l+20efKPYE4jNlZk6w==
-  dependencies:
-    "@material/dom" "=8.0.0-canary.774dcfc8e.0"
-    "@material/mwc-base" "^0.19.1"
-    "@material/ripple" "=8.0.0-canary.774dcfc8e.0"
-    lit-element "^2.3.0"
-    lit-html "^1.1.2"
-    tslib "^1.10.0"
-
-"@material/ripple@=8.0.0-canary.774dcfc8e.0":
-  version "8.0.0-canary.774dcfc8e.0"
-  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-8.0.0-canary.774dcfc8e.0.tgz#342e9c815a5d8a8fec4787be1cefaf7511a30eaa"
-  integrity sha512-mxfa+aNQuCJ6wQbjfs2k7hxHuCcISfGU9hJixTTykJqKeE1h3N045TxTyVSeroXf38SyWA4T2303/W7nkPbJpg==
-  dependencies:
-    "@material/animation" "8.0.0-canary.774dcfc8e.0"
-    "@material/base" "8.0.0-canary.774dcfc8e.0"
-    "@material/dom" "8.0.0-canary.774dcfc8e.0"
-    "@material/feature-targeting" "8.0.0-canary.774dcfc8e.0"
-    "@material/theme" "8.0.0-canary.774dcfc8e.0"
-    tslib "^1.9.3"
-
-"@material/theme@8.0.0-canary.774dcfc8e.0":
-  version "8.0.0-canary.774dcfc8e.0"
-  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-8.0.0-canary.774dcfc8e.0.tgz#07322fb5da2a8a6f84773c05e9edaa7ebbfe4440"
-  integrity sha512-dGQHZ5nHVdgdmG/PtD6A/oJifWdou1Kx3JAu0D8JtopdyUrNFKHU24qj6SIto7LLm+pa05RPnfxSHWsBvDyLTA==
-  dependencies:
-    "@material/feature-targeting" "8.0.0-canary.774dcfc8e.0"
-
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -4580,13 +4512,6 @@ lit-analyzer@1.2.1:
     vscode-html-languageservice "3.1.0"
     web-component-analyzer "~1.1.1"
 
-lit-element@^2.3.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.5.1.tgz#3fa74b121a6cd22902409ae3859b7847d01aa6b6"
-  integrity sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==
-  dependencies:
-    lit-html "^1.1.1"
-
 lit-element@^3.3.0, lit-element@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.3.3.tgz#10bc19702b96ef5416cf7a70177255bfb17b3209"
@@ -4595,11 +4520,6 @@ lit-element@^3.3.0, lit-element@^3.3.2:
     "@lit-labs/ssr-dom-shim" "^1.1.0"
     "@lit/reactive-element" "^1.3.0"
     lit-html "^2.8.0"
-
-lit-html@^1.1.1, lit-html@^1.1.2:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.4.1.tgz#0c6f3ee4ad4eb610a49831787f0478ad8e9ae5e0"
-  integrity sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==
 
 lit-html@^2.7.5, lit-html@^2.8.0:
   version "2.8.0"
@@ -7189,7 +7109,7 @@ tslib@2.0.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
BREAKING CHANGE: CSS variables `--mdc-ripple-*` are no longer supported. These have been replaced with `--button-card-ripple-*` variables. You will need to update your configuration.

Closes #887 