### PR TITLE
feat(actions): Official support for native javascript actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ All the fields support templates, see [templates](#javascript-templates). You ma
 
 | Name | Type | Default | Supported options | Description |
 | --- | --- | --- | --- | --- |
-| `action` | string | `toggle` | `more-info`, `toggle`, `call-service`, `none`, `navigate`, `url`, `assist` | Action to perform |
+| `action` | string | `toggle` | `more-info`, `toggle`, `call-service`, `none`, `navigate`, `url`, `assist`, `javascript` | Action to perform |
 | `entity` | string | none | Any entity id | **Only valid for `action: more-info`** to override the entity on which you want to call `more-info` |
 | `target` | object | none |  | Only works with `call-service`. Follows the [home-assistant syntax](https://www.home-assistant.io/docs/scripts/service-calls/#targeting-areas-and-devices) |
 | `navigation_path` | string | none | Eg: `/lovelace/0/` | Path to navigate to (e.g. `/lovelace/0/`) when action defined as navigate |
@@ -168,7 +168,8 @@ All the fields support templates, see [templates](#javascript-templates). You ma
 | `haptic` | string | none | `success`, `warning`, `failure`, `light`, `medium`, `heavy`, `selection` | Haptic feedback for the [Beta IOS App](http://home-assistant.io/ios/beta) |
 | `repeat` | number | none | eg: `500` | For a hold_action, you can optionally configure the action to repeat while the button is being held down (for example, to repeatedly increase the volume of a media player). Define the number of milliseconds between repeat actions here. Not available for `press` or `release` actions. |
 | `repeat_limit` | number | none | eg: `5` | For Hold action and if `repeat` if defined, it will stop calling the action after the `repeat_limit` has been reached. Not available for `press` or `release` actions. |
-| `confirmation` | object | none | See [confirmation](#confirmation) | Display a confirmation popup, overrides the default `confirmation` object |
+| `confirmation` | object | none | See [confirmation](#confirmation) | Display a confirmation popup, overrides the default `confirmation` object. :warning: Not available for `javascript` actions |
+| `javascript` | string | none | A button card template which contains the javascript code to execute. |
 | `sound` | string | none | eg: `/local/click.mp3` | The path to an audio file (eg: `/local/click.mp3`, `https://some.audio.file/file.wav` or `media-source://media_source/local/click.mp3`). Plays a sound in your browswer when the corresponding action is used. Can be a different sound for each action. Supports also `media-source://` type URLs. This field supports templates. |
 
 Example - specifying fields directly:
@@ -200,6 +201,18 @@ variables:
     ]]]
 entity: light.bed_light
 tap_action: '[[[ return variables.my_action_object ]]]'
+```
+
+Example - Using a javascript action:
+
+```yaml
+type: custom:button-card
+icon: mdi:console
+name: Javascript Action
+tap_action:
+  action: javascript
+  javascript: |
+    [[[ alert("Hello from button card"); ]]]
 ```
 
 ### Confirmation

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -21,7 +21,6 @@ import {
   ColorType,
   CustomFields,
   EntityPicture,
-  ActionConfig,
   ActionEventData,
 } from './types/types';
 import { actionHandler } from './action-handler';

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -22,6 +22,8 @@ import {
   CustomFields,
   EntityPicture,
   ActionEventData,
+  EvaluatedActionConfig,
+  ActionConfig,
 } from './types/types';
 import { actionHandler } from './action-handler';
 import {
@@ -236,7 +238,10 @@ class ButtonCard extends LitElement {
 
       this._evaluateVariablesSkipError(this._stateObj);
 
-      if (this._config?.press_action?.action === 'none' && this._config?.release_action?.action === 'none') {
+      if (
+        !this._isActionDoingSomething(this._stateObj, this._config!.press_action) &&
+        !this._isActionDoingSomething(this._stateObj, this._config!.release_action)
+      ) {
         if (this._config!.entity && DOMAINS_TOGGLE.has(computeDomain(this._config!.entity))) {
           this._config = {
             tap_action: { action: 'toggle' },
@@ -269,28 +274,28 @@ class ButtonCard extends LitElement {
         };
       }
 
-      if (this._config!.press_action?.action !== 'none' || this._config!.release_action?.action !== 'none') {
+      if (
+        this._isActionDoingSomething(this._stateObj, this._config!.press_action) ||
+        this._isActionDoingSomething(this._stateObj, this._config!.release_action)
+      ) {
         if (
-          typeof this._config!.tap_action === 'string' ||
-          this._config!.tap_action?.action !== 'none' ||
-          typeof this._config!.hold_action === 'string' ||
-          this._config!.hold_action?.action !== 'none' ||
-          typeof this._config!.double_tap_action === 'string' ||
-          this._config!.double_tap_action?.action !== 'none'
+          this._isActionDoingSomething(this._stateObj, this._config!.tap_action) ||
+          this._isActionDoingSomething(this._stateObj, this._config!.hold_action) ||
+          this._isActionDoingSomething(this._stateObj, this._config!.double_tap_action)
         ) {
           throw new Error(
             'button-card: If you use press_action or release_action, then tap_action, hold_action and double_tap_action must be "none" or not set at all.',
           );
         }
       }
-      if (this._config!.icon_press_action?.action !== 'none' || this._config!.icon_release_action?.action !== 'none') {
+      if (
+        this._isActionDoingSomething(this._stateObj, this._config!.icon_press_action) ||
+        this._isActionDoingSomething(this._stateObj, this._config!.icon_release_action)
+      ) {
         if (
-          typeof this._config!.icon_tap_action === 'string' ||
-          this._config!.icon_tap_action?.action !== 'none' ||
-          typeof this._config!.icon_hold_action === 'string' ||
-          this._config!.icon_hold_action?.action !== 'none' ||
-          typeof this._config!.icon_double_tap_action === 'string' ||
-          this._config!.icon_double_tap_action?.action !== 'none'
+          this._isActionDoingSomething(this._stateObj, this._config!.icon_tap_action) ||
+          this._isActionDoingSomething(this._stateObj, this._config!.icon_hold_action) ||
+          this._isActionDoingSomething(this._stateObj, this._config!.icon_double_tap_action)
         ) {
           throw new Error(
             'button-card: If you use icon_press_action or icon_release_action, then icon_tap_action, icon_hold_action and icon_double_tap_action must be "none" or not set at all.',
@@ -1155,6 +1160,7 @@ class ButtonCard extends LitElement {
           </style>
         `
       : html``;
+    const holdActionEvaluated = this._partialActionEval(this._config!.hold_action);
     return html`
       ${extraStyles}
       <div id="aspect-ratio" style=${styleMap(aspectRatio)}>
@@ -1164,10 +1170,10 @@ class ButtonCard extends LitElement {
           style=${styleMap(cardStyle)}
           @action=${this._handleAction}
           .actionHandler=${actionHandler({
-            hasDoubleClick: this._config!.double_tap_action!.action !== 'none',
-            hasHold: this._config!.hold_action!.action !== 'none',
-            repeat: this._config!.hold_action!.repeat,
-            repeatLimit: this._config!.hold_action!.repeat_limit,
+            hasDoubleClick: this._isActionDoingSomething(this._stateObj, this._config!.double_tap_action),
+            hasHold: this._isActionDoingSomething(this._stateObj, this._config!.hold_action),
+            repeat: holdActionEvaluated?.repeat,
+            repeatLimit: holdActionEvaluated?.repeat_limit,
             isMomentary: this._cardMomentary,
           })}
           .config="${this._config}"
@@ -1320,6 +1326,7 @@ class ButtonCard extends LitElement {
       if (state) {
         domain = computeStateDomain(state);
       }
+      const iconHoldActionEvaluated = this._partialActionEval(this._config!.icon_hold_action);
       return html`
         <div id="img-cell" style=${styleMap(imgCellStyleFromConfig)}>
           ${shouldShowIcon && !entityPicture && !liveStream
@@ -1346,10 +1353,10 @@ class ButtonCard extends LitElement {
                   @touchcancel=${this._hasIconActions ? this._sendToParent : undefined}
                   .actionHandler=${this._hasIconActions
                     ? actionHandler({
-                        hasDoubleClick: this._config!.icon_double_tap_action!.action !== 'none',
-                        hasHold: this._config!.icon_hold_action!.action !== 'none',
-                        repeat: this._config!.icon_hold_action!.repeat,
-                        repeatLimit: this._config!.icon_hold_action!.repeat_limit,
+                        hasDoubleClick: this._isActionDoingSomething(state, this._config!.icon_double_tap_action),
+                        hasHold: this._isActionDoingSomething(state, this._config!.icon_hold_action),
+                        repeat: iconHoldActionEvaluated?.repeat,
+                        repeatLimit: iconHoldActionEvaluated?.repeat_limit,
                         isMomentary: this._iconMomentary,
                       })
                     : undefined}
@@ -1377,10 +1384,10 @@ class ButtonCard extends LitElement {
                   @touchcancel=${this._hasIconActions ? this._sendToParent : undefined}
                   .actionHandler=${this._hasIconActions
                     ? actionHandler({
-                        hasDoubleClick: this._config!.icon_double_tap_action!.action !== 'none',
-                        hasHold: this._config!.icon_hold_action!.action !== 'none',
-                        repeat: this._config!.icon_hold_action!.repeat,
-                        repeatLimit: this._config!.icon_hold_action!.repeat_limit,
+                        hasDoubleClick: this._isActionDoingSomething(state, this._config!.icon_double_tap_action),
+                        hasHold: this._isActionDoingSomething(state, this._config!.icon_hold_action),
+                        repeat: iconHoldActionEvaluated?.repeat,
+                        repeatLimit: iconHoldActionEvaluated?.repeat_limit,
                         isMomentary: this._iconMomentary,
                       })
                     : undefined}
@@ -1568,6 +1575,20 @@ class ButtonCard extends LitElement {
       min_rows: 1,
       min_columns: 1,
     };
+  }
+
+  private _partialActionEval(actionConfig: ActionConfig | undefined): EvaluatedActionConfig {
+    if (!actionConfig) {
+      return { action: 'none' };
+    }
+    if (typeof actionConfig === 'string') {
+      return this._objectEvalTemplate(this._stateObj, actionConfig) as EvaluatedActionConfig;
+    }
+    const evaluatedAction: EvaluatedActionConfig = copy(actionConfig);
+    ['action', 'repeat', 'repeat_limit'].forEach((key) => {
+      evaluatedAction[key] = this._getTemplateOrValue(this._stateObj, evaluatedAction[key]);
+    });
+    return evaluatedAction;
   }
 
   private _evalActions(config: ButtonCardConfig, action: string): ActionEventData {

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -22,6 +22,7 @@ import {
   CustomFields,
   EntityPicture,
   ActionConfig,
+  ActionEventData,
 } from './types/types';
 import { actionHandler } from './action-handler';
 import {
@@ -1018,38 +1019,41 @@ class ButtonCard extends LitElement {
     });
   }
 
+  private _isActionDoingSomething(state: HassEntity | undefined, actionConfig: any | undefined): boolean {
+    if (!actionConfig) return false;
+    if (typeof actionConfig === 'string') {
+      const evaledActionObj = this._getTemplateOrValue(state, actionConfig);
+      return !!(evaledActionObj && !['none', null, undefined].includes(evaledActionObj.action));
+    } else if (typeof actionConfig === 'object' && actionConfig.action) {
+      const evaledActionString = this._objectEvalTemplate(state, actionConfig.action);
+      return !['none', null, undefined].includes(evaledActionString);
+    }
+    return false;
+  }
+
   private _computeIsClickable(state: HassEntity | undefined, configState: StateConfig | undefined): void {
-    const tap_action: ActionConfig = this._objectEvalTemplate(state, this._config!.tap_action);
-    const hold_action: ActionConfig = this._objectEvalTemplate(state, this._config!.hold_action);
-    const double_tap_action: ActionConfig = this._objectEvalTemplate(state, this._config!.double_tap_action);
-    const press_action: ActionConfig = this._objectEvalTemplate(state, this._config!.press_action);
-    const release_action: ActionConfig = this._objectEvalTemplate(state, this._config!.release_action);
-    const icon_tap_action: ActionConfig = this._objectEvalTemplate(state, this._config!.icon_tap_action);
-    const icon_hold_action: ActionConfig = this._objectEvalTemplate(state, this._config!.icon_hold_action);
-    const icon_double_tap_action: ActionConfig = this._objectEvalTemplate(state, this._config!.icon_double_tap_action);
-    const icon_press_action: ActionConfig = this._objectEvalTemplate(state, this._config!.icon_press_action);
-    const icon_release_action: ActionConfig = this._objectEvalTemplate(state, this._config!.icon_release_action);
+    const tapActive = this._isActionDoingSomething(state, this._config!.tap_action);
+    const holdActive = this._isActionDoingSomething(state, this._config!.hold_action);
+    const doubleTapActive = this._isActionDoingSomething(state, this._config!.double_tap_action);
+    const pressActive = this._isActionDoingSomething(state, this._config!.press_action);
+    const releaseActive = this._isActionDoingSomething(state, this._config!.release_action);
+    const iconTapActive = this._isActionDoingSomething(state, this._config!.icon_tap_action);
+    const iconHoldActive = this._isActionDoingSomething(state, this._config!.icon_hold_action);
+    const iconDoubleTapActive = this._isActionDoingSomething(state, this._config!.icon_double_tap_action);
+    const iconPressActive = this._isActionDoingSomething(state, this._config!.icon_press_action);
+    const iconReleaseActive = this._isActionDoingSomething(state, this._config!.icon_release_action);
     const hasChildCards =
       this._hasChildCards(this._config!.custom_fields) ||
       !!(configState && this._hasChildCards(configState.custom_fields));
 
-    const cardHasActions =
-      tap_action?.action != 'none' ||
-      hold_action?.action != 'none' ||
-      double_tap_action?.action != 'none' ||
-      press_action?.action != 'none' ||
-      release_action?.action != 'none';
+    const cardHasActions = tapActive || holdActive || doubleTapActive || pressActive || releaseActive;
     this._cardClickable = cardHasActions || hasChildCards;
     this._hasIconActions =
-      icon_tap_action?.action != 'none' ||
-      icon_hold_action?.action != 'none' ||
-      icon_double_tap_action?.action != 'none' ||
-      icon_press_action?.action != 'none' ||
-      icon_release_action?.action != 'none';
+      iconTapActive || iconHoldActive || iconDoubleTapActive || iconPressActive || iconReleaseActive;
     this._iconClickable = this._cardClickable || this._hasIconActions;
     this._cardRipple = cardHasActions || this._hasIconActions;
-    this._cardMomentary = press_action?.action != 'none' || release_action?.action != 'none';
-    this._iconMomentary = icon_press_action?.action != 'none' || icon_release_action?.action != 'none';
+    this._cardMomentary = pressActive || releaseActive;
+    this._iconMomentary = iconPressActive || iconReleaseActive;
   }
 
   private _rotate(configState: StateConfig | undefined): boolean {
@@ -1567,8 +1571,7 @@ class ButtonCard extends LitElement {
     };
   }
 
-  private _evalActions(config: ButtonCardConfig, action: string): ButtonCardConfig {
-    const configDuplicate = copy(config);
+  private _evalActions(config: ButtonCardConfig, action: string): ActionEventData {
     /* eslint no-param-reassign: 0 */
     const __evalObject = (configEval: any): any => {
       if (!configEval) {
@@ -1586,21 +1589,40 @@ class ButtonCard extends LitElement {
       });
       return configEval;
     };
-    if (configDuplicate[action]?.service_data?.entity_id === 'entity') {
-      configDuplicate[action].service_data.entity_id = config.entity;
-    }
-    if (configDuplicate[action]?.data?.entity_id === 'entity') {
-      configDuplicate[action].data.entity_id = config.entity;
-    }
-    configDuplicate[action] = __evalObject(configDuplicate[action]);
-    if (!configDuplicate[action].confirmation && configDuplicate.confirmation) {
-      configDuplicate[action].confirmation = __evalObject(configDuplicate.confirmation);
-    }
-    if (configDuplicate[action]?.entity) {
-      configDuplicate.entity = configDuplicate[action].entity;
+
+    const actionEventData: ActionEventData = {};
+    if (typeof config[action] === 'string') {
+      actionEventData[action] = this._objectEvalTemplate(this._stateObj, config[action]);
+    } else {
+      actionEventData[action] = copy(config[action]);
     }
 
-    return configDuplicate;
+    // remove javascript string before evaluating and set it again after to avoid executing the JS right now.
+    let jsAction = undefined;
+    if (actionEventData[action]?.javascript) {
+      jsAction = actionEventData[action].javascript;
+      delete actionEventData[action].javascript;
+    }
+
+    actionEventData[action] = __evalObject(actionEventData[action]);
+    if (jsAction) actionEventData[action].javascript = jsAction;
+
+    if (actionEventData[action]?.service_data?.entity_id === 'entity') {
+      actionEventData[action].service_data.entity_id = config.entity;
+    }
+    if (actionEventData[action]?.data?.entity_id === 'entity') {
+      actionEventData[action].data.entity_id = config.entity;
+    }
+    if (!actionEventData[action].confirmation && config.confirmation) {
+      actionEventData[action].confirmation = __evalObject(copy(config.confirmation));
+    }
+    if (config[action]?.entity) {
+      actionEventData.entity = config[action].entity;
+    } else {
+      actionEventData.entity = config.entity;
+    }
+
+    return actionEventData;
   }
 
   private _handleRippleIcon(ev: PointerEvent): void {
@@ -1646,8 +1668,7 @@ class ButtonCard extends LitElement {
       if (!config) return;
       const action = ev.detail.action;
       const actionKey = `icon_${action}_action`;
-      const localAction = this._evalActions(config, actionKey);
-      if (localAction[actionKey]?.action !== 'none') {
+      if (this._isActionDoingSomething(this._stateObj, config[actionKey])) {
         this._runAction(ev.detail.action, { isIcon: true });
       }
     }
@@ -1655,7 +1676,13 @@ class ButtonCard extends LitElement {
 
   private _handleAction(ev: any): void {
     if (ev.detail?.action) {
-      this._runAction(ev.detail.action, { isIcon: false });
+      const config = this._config;
+      if (!config) return;
+      const action = ev.detail.action;
+      const actionKey = `${action}_action`;
+      if (this._isActionDoingSomething(this._stateObj, config[actionKey])) {
+        this._runAction(ev.detail.action, { isIcon: false });
+      }
     }
   }
 
@@ -1663,11 +1690,8 @@ class ButtonCard extends LitElement {
     const config = this._config;
     if (!config) return;
     const actionKey = options.isIcon ? `icon_${action}_action` : `${action}_action`;
+
     const localAction = this._evalActions(config, actionKey);
-    // Check if the action is configured (not 'none')
-    if (!localAction[actionKey] || localAction[actionKey].action === 'none') {
-      return;
-    }
 
     const soundUrl = localAction[actionKey].sound;
     if (soundUrl) {
@@ -1685,19 +1709,25 @@ class ButtonCard extends LitElement {
         sound.play();
       }
     }
-    let actionToExecute = action;
-    if (options.isIcon) {
-      if (['press', 'release'].includes(action)) {
-        localAction['tap_action'] = localAction[`icon_${action}_action`];
+
+    if (localAction[actionKey].action === 'javascript' && localAction[actionKey].javascript) {
+      // executes the javascript action.
+      this._getTemplateOrValue(this._stateObj, localAction[actionKey].javascript);
+    } else {
+      let actionToExecute = action;
+      if (options.isIcon) {
+        if (['press', 'release'].includes(action)) {
+          localAction['tap_action'] = localAction[`icon_${action}_action`];
+          actionToExecute = 'tap';
+        } else {
+          localAction[`${action}_action`] = localAction[`icon_${action}_action`];
+        }
+      } else if (['press', 'release'].includes(action)) {
+        localAction['tap_action'] = localAction[`${action}_action`];
         actionToExecute = 'tap';
-      } else {
-        localAction[`${action}_action`] = localAction[`icon_${action}_action`];
       }
-    } else if (['press', 'release'].includes(action)) {
-      localAction['tap_action'] = localAction[`${action}_action`];
-      actionToExecute = 'tap';
+      handleAction(this, this._hass!, localAction, actionToExecute);
     }
-    handleAction(this, this._hass!, localAction, actionToExecute);
   }
 
   private _handleUnlockType(ev): void {

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -1029,7 +1029,7 @@ class ButtonCard extends LitElement {
       const evaledActionObj = this._getTemplateOrValue(state, actionConfig);
       return !!(evaledActionObj && !['none', null, undefined].includes(evaledActionObj.action));
     } else if (typeof actionConfig === 'object' && actionConfig.action) {
-      const evaledActionString = this._objectEvalTemplate(state, actionConfig.action);
+      const evaledActionString = this._getTemplateOrValue(state, actionConfig.action);
       return !['none', null, undefined].includes(evaledActionString);
     }
     return false;
@@ -1710,7 +1710,6 @@ class ButtonCard extends LitElement {
     const config = this._config;
     if (!config) return;
     const actionKey = options.isIcon ? `icon_${action}_action` : `${action}_action`;
-
     const localAction = this._evalActions(config, actionKey);
 
     const soundUrl = localAction[actionKey].sound;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -245,7 +245,7 @@ export interface JavascriptActionConfig extends BaseActionConfig {
 
 export interface BaseActionConfig {
   action: string;
-  confirmation?: ConfirmationRestrictionConfig;
+  confirmation?: ConfirmationRestrictionConfig | string;
   repeat?: number;
   repeat_limit?: number;
   sound?: string;
@@ -269,7 +269,10 @@ export type ActionConfig =
   | AssistActionConfig
   | NoActionConfig
   | CustomActionConfig
-  | JavascriptActionConfig;
+  | JavascriptActionConfig
+  | string;
+
+export type EvaluatedActionConfig = Exclude<ActionConfig, string>;
 
 export type Constructor<T = any> = new (...args: any[]) => T;
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -238,6 +238,11 @@ export interface AssistActionConfig extends BaseActionConfig {
   start_listening?: boolean;
 }
 
+export interface JavascriptActionConfig extends BaseActionConfig {
+  action: 'javascript';
+  javascript: string;
+}
+
 export interface BaseActionConfig {
   action: string;
   confirmation?: ConfirmationRestrictionConfig;
@@ -263,8 +268,24 @@ export type ActionConfig =
   | MoreInfoActionConfig
   | AssistActionConfig
   | NoActionConfig
-  | CustomActionConfig;
+  | CustomActionConfig
+  | JavascriptActionConfig;
 
 export type Constructor<T = any> = new (...args: any[]) => T;
 
 export type EntityPicture = Promise<string> | string | undefined;
+
+export interface ActionEventData {
+  tap_action?: ActionConfig;
+  hold_action?: ActionConfig;
+  double_tap_action?: ActionConfig;
+  press_action?: ActionConfig;
+  release_action?: ActionConfig;
+  icon_tap_action?: ActionConfig;
+  icon_hold_action?: ActionConfig;
+  icon_double_tap_action?: ActionConfig;
+  icon_press_action?: ActionConfig;
+  icon_release_action?: ActionConfig;
+  entity?: string;
+  confirmation?: string;
+}

--- a/test/ui-lovelace.yaml
+++ b/test/ui-lovelace.yaml
@@ -1567,6 +1567,21 @@ views:
             grid_options:
               rows: 2
               columns: 4
+          - type: 'custom:button-card'
+            icon: mdi:console
+            name: javascript action
+            tap_action:
+              action: javascript
+              javascript: >
+                [[[
+                  alert("Hello from button card");
+                ]]]
+
+
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
 
       - type: grid
         cards:


### PR DESCRIPTION
BREAKING CHANGE: Some of you were using hacks to execute javascript actions. This release officially implements `action: javascript` and this is the **only supported** way to execute javascript actions going forward. Any other configuration might execute the javascript action while the card is first displayed. Please update your config accordingly and read the updated documentation.

Closes #1021 