### PR TITLE
fix(actions): avoid executing invalid actions configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,18 +158,22 @@ All the fields support templates, see [templates](#javascript-templates). You ma
 
 | Name | Type | Default | Supported options | Description |
 | --- | --- | --- | --- | --- |
-| `action` | string | `toggle` | `more-info`, `toggle`, `call-service`, `none`, `navigate`, `url`, `assist`, `javascript` | Action to perform |
-| `entity` | string | none | Any entity id | **Only valid for `action: more-info`** to override the entity on which you want to call `more-info` |
-| `target` | object | none |  | Only works with `call-service`. Follows the [home-assistant syntax](https://www.home-assistant.io/docs/scripts/service-calls/#targeting-areas-and-devices) |
-| `navigation_path` | string | none | Eg: `/lovelace/0/` | Path to navigate to (e.g. `/lovelace/0/`) when action defined as navigate |
+| `action` | string | `toggle` | `more-info`, `toggle`, `call-service`, `perform-action`, `none`, `navigate`, `url`, `assist`, `javascript` | Action to perform |
+| `entity` | string | none | Any entity id | **Only valid for `action: more-info` or `action: toggle`** to override the entity on which you want to call `more-info` |
+| `target` | object | none |  | Only works with `call-service` or `perform-action`. Follows the [home-assistant syntax](https://www.home-assistant.io/docs/scripts/service-calls/#targeting-areas-and-devices) |
+| `navigation_path` | string | none | Eg: `/lovelace/0/` | Path to navigate to (e.g. `/lovelace/0/`) when action defined as `navigate` |
+| `navigation_replace` | boolean | none | `true`, `false` | Whether to replace the current page in the the history with the new URL when the action is defined as `navigate` |
 | `url_path` | string | none | Eg: `https://www.google.fr` | URL to open on click when action is `url`. The URL will open in a new tab |
 | `service` | string | none | Any service | Service to call (e.g. `media_player.media_play_pause`) when `action` defined as `call-service` |
-| `data` or `service_data` | object | none | Any service data | Service data to include (e.g. `entity_id: media_player.bedroom`) when `action` defined as `call-service`. If your `data` requires an `entity_id`, you can use the keyword `entity`, this will actually call the service on the entity defined in the main configuration of this card. Useful for [configuration templates](#configuration-templates) |
+| `perform_action` | string | none | Any action | Action to call (e.g. `media_player.media_play_pause`) when `action` defined as `perform-action` |
+| `data` or `service_data` | object | none | Any service data | Service data to include (e.g. `entity_id: media_player.bedroom`) when `action` defined as `call-service` or `perform-action`. If your `data` requires an `entity_id`, you can use the keyword `entity`, this will actually call the service on the entity defined in the main configuration of this card. Useful for [configuration templates](#configuration-templates) |
 | `haptic` | string | none | `success`, `warning`, `failure`, `light`, `medium`, `heavy`, `selection` | Haptic feedback for the [Beta IOS App](http://home-assistant.io/ios/beta) |
 | `repeat` | number | none | eg: `500` | For a hold_action, you can optionally configure the action to repeat while the button is being held down (for example, to repeatedly increase the volume of a media player). Define the number of milliseconds between repeat actions here. Not available for `press` or `release` actions. |
 | `repeat_limit` | number | none | eg: `5` | For Hold action and if `repeat` if defined, it will stop calling the action after the `repeat_limit` has been reached. Not available for `press` or `release` actions. |
 | `confirmation` | object | none | See [confirmation](#confirmation) | Display a confirmation popup, overrides the default `confirmation` object. :warning: Not available for `javascript` actions |
-| `javascript` | string | none | A button card template which contains the javascript code to execute. |
+| `javascript` | string | none | any javascript template | A button card javascript template which contains the javascript code to execute. |
+| `pipeline_id` | string | none | `last_used`, `prefered`, pipeline ID | Assist pipeline to use when the action is defined as `assist`. It can be either `last_used`, `preferred`, or a pipeline id. |
+| `start_listening` | boolean | none | `true`, `false` | If supported, listen for voice commands when opening the assist dialog and the action is defined as `assist`. |
 | `sound` | string | none | eg: `/local/click.mp3` | The path to an audio file (eg: `/local/click.mp3`, `https://some.audio.file/file.wav` or `media-source://media_source/local/click.mp3`). Plays a sound in your browswer when the corresponding action is used. Can be a different sound for each action. Supports also `media-source://` type URLs. This field supports templates. |
 
 Example - specifying fields directly:

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -24,6 +24,16 @@ import {
   ActionEventData,
   EvaluatedActionConfig,
   ActionConfig,
+  JavascriptActionConfig,
+  NoActionConfig,
+  ToggleActionConfig,
+  MoreInfoActionConfig,
+  NavigateActionConfig,
+  UrlActionConfig,
+  CallServiceActionConfig,
+  PerformActionActionConfig,
+  AssistActionConfig,
+  CustomActionConfig,
 } from './types/types';
 import { actionHandler } from './action-handler';
 import {
@@ -1592,57 +1602,133 @@ class ButtonCard extends LitElement {
   }
 
   private _evalActions(config: ButtonCardConfig, action: string): ActionEventData {
-    /* eslint no-param-reassign: 0 */
-    const __evalObject = (configEval: any): any => {
-      if (!configEval) {
-        return configEval;
-      }
-      if (typeof configEval === 'string') {
-        return this._getTemplateOrValue(this._stateObj, configEval);
-      }
-      Object.keys(configEval).forEach((key) => {
-        if (typeof configEval[key] === 'object') {
-          configEval[key] = __evalObject(configEval[key]);
-        } else {
-          configEval[key] = this._getTemplateOrValue(this._stateObj, configEval[key]);
-        }
-      });
-      return configEval;
-    };
-
-    const actionEventData: ActionEventData = {};
+    const localActionEventData: ActionEventData = {};
     if (typeof config[action] === 'string') {
-      actionEventData[action] = this._objectEvalTemplate(this._stateObj, config[action]);
+      localActionEventData[action] = this._objectEvalTemplate(this._stateObj, config[action]);
     } else {
-      actionEventData[action] = copy(config[action]);
+      localActionEventData[action] = copy(config[action]);
     }
 
-    // remove javascript string before evaluating and set it again after to avoid executing the JS right now.
-    let jsAction = undefined;
-    if (actionEventData[action]?.javascript) {
-      jsAction = actionEventData[action].javascript;
-      delete actionEventData[action].javascript;
+    const actionType = this._getTemplateOrValue(this._stateObj, localActionEventData[action]?.action);
+
+    if (actionType === 'none' || !actionType) {
+      const noAction: ActionEventData = {};
+      noAction[action] = { action: 'none' } as NoActionConfig;
+      return noAction;
     }
 
-    actionEventData[action] = __evalObject(actionEventData[action]);
-    if (jsAction) actionEventData[action].javascript = jsAction;
+    const repeat = this._getTemplateOrValue(this._stateObj, localActionEventData[action]?.repeat);
+    const repeat_limit = this._getTemplateOrValue(this._stateObj, localActionEventData[action]?.repeat_limit);
+    const sound = this._getTemplateOrValue(this._stateObj, localActionEventData[action]?.sound);
+    let confirmation = this._getTemplateOrValue(this._stateObj, localActionEventData[action]?.confirmation);
+    if (!confirmation && config.confirmation) {
+      confirmation = this._objectEvalTemplate(this._stateObj, config.confirmation);
+    }
+    const haptic = this._getTemplateOrValue(this._stateObj, localActionEventData[action]?.haptic);
 
-    if (actionEventData[action]?.service_data?.entity_id === 'entity') {
-      actionEventData[action].service_data.entity_id = config.entity;
-    }
-    if (actionEventData[action]?.data?.entity_id === 'entity') {
-      actionEventData[action].data.entity_id = config.entity;
-    }
-    if (!actionEventData[action].confirmation && config.confirmation) {
-      actionEventData[action].confirmation = __evalObject(copy(config.confirmation));
-    }
-    if (config[action]?.entity) {
-      actionEventData.entity = config[action].entity;
-    } else {
-      actionEventData.entity = config.entity;
+    const actionData: ActionEventData = {};
+    switch (actionType) {
+      case 'javascript':
+        actionData[action] = {
+          action: 'javascript',
+          javascript: localActionEventData[action].javascript,
+        } as JavascriptActionConfig;
+        break;
+
+      case 'toggle':
+        actionData.entity = this._getTemplateOrValue(this._stateObj, config[action]?.entity || config.entity);
+        actionData[action] = {
+          action: 'toggle',
+        } as ToggleActionConfig;
+        break;
+
+      case 'more-info':
+        actionData.entity = this._getTemplateOrValue(this._stateObj, config[action]?.entity || config.entity);
+        actionData[action] = {
+          action: 'more-info',
+        } as MoreInfoActionConfig;
+        break;
+
+      case 'navigate':
+        actionData[action] = {
+          action: 'navigate',
+          navigation_path: this._getTemplateOrValue(this._stateObj, localActionEventData[action]?.navigation_path),
+          navigation_replace: this._getTemplateOrValue(
+            this._stateObj,
+            localActionEventData[action]?.navigation_replace,
+          ),
+        } as NavigateActionConfig;
+        break;
+
+      case 'url':
+        actionData[action] = {
+          action: 'url',
+          url_path: this._getTemplateOrValue(this._stateObj, localActionEventData[action]?.url_path),
+        } as UrlActionConfig;
+        break;
+
+      case 'call-service':
+        actionData[action] = {
+          action: 'call-service',
+          service: this._getTemplateOrValue(this._stateObj, localActionEventData[action]?.service),
+          data: this._objectEvalTemplate(this._stateObj, localActionEventData[action]?.data),
+          target: this._objectEvalTemplate(this._stateObj, localActionEventData[action]?.target),
+          // kept for backward compatibility
+          service_data: this._objectEvalTemplate(this._stateObj, localActionEventData[action]?.service_data),
+        } as CallServiceActionConfig;
+        if (actionData[action].service_data?.entity_id === 'entity') {
+          actionData[action].service_data.entity_id = this._getTemplateOrValue(this._stateObj, config.entity);
+        }
+        if (actionData[action].data?.entity_id === 'entity') {
+          actionData[action].data.entity_id = this._getTemplateOrValue(this._stateObj, config.entity);
+        }
+        break;
+
+      case 'perform-action':
+        actionData[action] = {
+          action: 'perform-action',
+          perform_action: this._getTemplateOrValue(this._stateObj, localActionEventData[action]?.perform_action),
+          data: this._objectEvalTemplate(this._stateObj, localActionEventData[action]?.data),
+          target: this._objectEvalTemplate(this._stateObj, localActionEventData[action]?.target),
+          // kept for backward compatibility
+          service_data: this._objectEvalTemplate(this._stateObj, localActionEventData[action]?.service_data),
+        } as PerformActionActionConfig;
+        if (actionData[action].service_data?.entity_id === 'entity') {
+          actionData[action].service_data.entity_id = this._getTemplateOrValue(this._stateObj, config.entity);
+        }
+        if (actionData[action].data?.entity_id === 'entity') {
+          actionData[action].data.entity_id = this._getTemplateOrValue(this._stateObj, config.entity);
+        }
+        break;
+
+      case 'assist':
+        actionData[action] = {
+          action: 'assist',
+          pipeline_id: this._getTemplateOrValue(this._stateObj, localActionEventData[action]?.pipeline_id),
+          start_listening: this._getTemplateOrValue(this._stateObj, localActionEventData[action]?.start_listening),
+        } as AssistActionConfig;
+        break;
+
+      case 'fire-dom-event':
+        actionData[action] = {
+          action: 'fire-dom-event',
+          ...this._objectEvalTemplate(this._stateObj, localActionEventData[action]),
+        } as CustomActionConfig;
+        break;
+
+      default:
+        break;
     }
 
-    return actionEventData;
+    actionData[action] = {
+      ...actionData[action],
+      repeat,
+      repeat_limit,
+      sound,
+      haptic,
+    };
+    actionData.confirmation = confirmation;
+    return actionData;
   }
 
   private _handleRippleIcon(ev: PointerEvent): void {
@@ -1729,7 +1815,7 @@ class ButtonCard extends LitElement {
       }
     }
 
-    if (localAction[actionKey].action === 'javascript' && localAction[actionKey].javascript) {
+    if (localAction[actionKey].action === 'javascript') {
       // executes the javascript action.
       this._getTemplateOrValue(this._stateObj, localAction[actionKey].javascript);
     } else {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -210,9 +210,19 @@ export interface CallServiceActionConfig extends BaseActionConfig {
   data?: Record<string, unknown>;
 }
 
+export interface PerformActionActionConfig extends BaseActionConfig {
+  action: 'perform-action';
+  perform_action: string;
+  target?: HassServiceTarget;
+  // "service_data" is kept for backwards compatibility. Replaced by "data".
+  service_data?: Record<string, unknown>;
+  data?: Record<string, unknown>;
+}
+
 export interface NavigateActionConfig extends BaseActionConfig {
   action: 'navigate';
   navigation_path: string;
+  navigation_replace?: boolean;
 }
 
 export interface UrlActionConfig extends BaseActionConfig {
@@ -240,7 +250,7 @@ export interface AssistActionConfig extends BaseActionConfig {
 
 export interface JavascriptActionConfig extends BaseActionConfig {
   action: 'javascript';
-  javascript: string;
+  javascript?: string;
 }
 
 export interface BaseActionConfig {
@@ -249,6 +259,7 @@ export interface BaseActionConfig {
   repeat?: number;
   repeat_limit?: number;
   sound?: string;
+  haptic?: 'light' | 'medium' | 'heavy' | 'selection' | 'success' | 'warning' | 'error' | 'none';
 }
 
 export interface ConfirmationRestrictionConfig {
@@ -263,6 +274,7 @@ export interface RestrictionConfig {
 export type ActionConfig =
   | ToggleActionConfig
   | CallServiceActionConfig
+  | PerformActionActionConfig
   | NavigateActionConfig
   | UrlActionConfig
   | MoreInfoActionConfig
@@ -279,16 +291,16 @@ export type Constructor<T = any> = new (...args: any[]) => T;
 export type EntityPicture = Promise<string> | string | undefined;
 
 export interface ActionEventData {
-  tap_action?: ActionConfig;
-  hold_action?: ActionConfig;
-  double_tap_action?: ActionConfig;
-  press_action?: ActionConfig;
-  release_action?: ActionConfig;
-  icon_tap_action?: ActionConfig;
-  icon_hold_action?: ActionConfig;
-  icon_double_tap_action?: ActionConfig;
-  icon_press_action?: ActionConfig;
-  icon_release_action?: ActionConfig;
+  tap_action?: EvaluatedActionConfig;
+  hold_action?: EvaluatedActionConfig;
+  double_tap_action?: EvaluatedActionConfig;
+  press_action?: EvaluatedActionConfig;
+  release_action?: EvaluatedActionConfig;
+  icon_tap_action?: EvaluatedActionConfig;
+  icon_hold_action?: EvaluatedActionConfig;
+  icon_double_tap_action?: EvaluatedActionConfig;
+  icon_press_action?: EvaluatedActionConfig;
+  icon_release_action?: EvaluatedActionConfig;
   entity?: string;
-  confirmation?: string;
+  confirmation?: ConfirmationRestrictionConfig;
 }


### PR DESCRIPTION
BREAKING CHANGE: `*_action` stricly follow what is allowed in the configuration of this card (see updated documentation). If you used some hacks, it might break. If those hacks were created to run javascript code, you can now use `action: javascript` instead.