### PR TITLE
fix(tooltip): Set default z-index so long/wide tooltips are always visible.

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -78,6 +78,7 @@ export const styles = css`
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    z-index: var(--ha-tooltip-z-index, 1000);
   }
   :host(.tooltip:hover) span.tooltiptext {
     opacity: 1;


### PR DESCRIPTION
Fixes #1035