### PR TITLE
feat(protect): Support for `success_message`

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ This will popup a dialog box with password or PIN confirmation before running th
 | `pin` | string | none | any string composed of digits only | This will prompt for a PIN before running the action. Make sure you set this as a **string** like so `"1234"` |
 | `password` | string | none | any string | Setting this field will prompt for a password before running the action. |
 | `failure_message` | string | Fixed failure message | any string | If password or PIN is wrong, a toast will popup with this `failure_message` inside. |
+| `success_message` | string | none | any string | If password or PIN is valid, a toast will popup with the content of `success_message` inside. |
 
 This whole object supports templating.
 

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -1967,6 +1967,7 @@ class ButtonCard extends LitElement {
   private _protectedConfirmedCallback(code: string, type: 'pin' | 'password'): void {
     if (this._protectedAction && this._config) {
       if (code === this._protectedAction[NORMALISED_ACTION]?.protect?.[type]) {
+        this._sendToastMessage(this._protectedAction[NORMALISED_ACTION]?.protect?.success_message);
         delete this._protectedAction[NORMALISED_ACTION]?.protect;
         this._executeAction(this._protectedAction);
       } else {
@@ -1981,7 +1982,8 @@ class ButtonCard extends LitElement {
     this._protectedAction = undefined;
   }
 
-  private _sendToastMessage(message: string): void {
+  private _sendToastMessage(message: string | undefined): void {
+    if (message === undefined) return;
     this.dispatchEvent(
       new CustomEvent('hass-notification', {
         bubbles: true,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -276,6 +276,7 @@ export interface BaseActionConfig {
     pin?: string;
     password?: string;
     failure_message?: string;
+    success_message?: string;
   };
 }
 

--- a/test/ui-lovelace.yaml
+++ b/test/ui-lovelace.yaml
@@ -1634,6 +1634,7 @@ views:
               protect:
                 password: '1234'
                 failure_message: 'Bad password!'
+                success_message: 'Yay! Access granted!'
               action: perform-action
               perform_action: light.toggle
               data:


### PR DESCRIPTION
Closes #1046 