### PR TITLE
feat(protect): allow configuring `protect` at the card level

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Lovelace Button card for your entities.
 | `tooltip` | string | optional | Any string | (Not supported on touchscreens) You can configure the tooltip displayed after hovering the card for 1.5 seconds . Supports templates, see [templates](#javascript-templates) |
 | `disable_kbd` | boolean | `false` | `true` or `false` | Disable keyboard `enter` and `space` capture on the button itself. Usefull when you have input fields inside the button. |
 | `spinner` | boolean | `false` | `true` or `false` | See [spinner](#spinner). If `true`, it will lock the card and display a spinner. You'll need to use a template or `state` to make this variable. |
+| `protect` | object | none | See [protect](#protect) | Display a password or PIN confirmation popup. |
 
 ### Action
 
@@ -260,7 +261,7 @@ This will popup a dialog box with password or PIN confirmation before running th
 | `failure_message` | string | Fixed failure message | any string | If password or PIN is wrong, a toast will popup with this `failure_message` inside. |
 | `success_message` | string | none | any string | If password or PIN is valid, a toast will popup with the content of `success_message` inside. |
 
-This whole object supports templating.
+Protect can be defined at the card level, or at the action level. Both objects supports templating. The action level takes precedance over the card level, if both are defined, objects will be "merged" together (see eg. below).
 
 Eg:
 
@@ -276,6 +277,29 @@ hold_action:
     entity_id: switch.aquarium_pump
   protect:
     pin: '123456'
+```
+
+Defining a PIN for all actions but one:
+
+```yaml
+type: custom:button-card
+entity: light.aquarium
+protect: # globally enables the PIN for all actions
+  pin: '1234'
+  success_message: 'PIN is correct!'
+  failure_message: 'PIN is wrong!'
+tap_action:
+  action: toggle
+hold_action:
+  action: perform-action
+  perform_action: switch.toggle
+  target:
+    entity_id: switch.aquarium_pump
+icon_tap_action:
+  action: more-info
+  entity: sensor.aquarium_temperature
+  protect:
+    pin: '' # Setting this to an empty string disables the pin for this action only.
 ```
 
 ### Multi-actions

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -1675,7 +1675,10 @@ class ButtonCard extends LitElement {
       confirmation = this._objectEvalTemplate(this._stateObj, config.confirmation);
     }
     const haptic = this._getTemplateOrValue(this._stateObj, evaledActionConfig?.haptic);
-    const protect = this._objectEvalTemplate(this._stateObj, evaledActionConfig?.protect);
+    const protect = {
+      ...this._objectEvalTemplate(this._stateObj, config.protect),
+      ...this._objectEvalTemplate(this._stateObj, evaledActionConfig?.protect),
+    };
 
     const actionData: ActionEventData = {};
     switch (actionType) {
@@ -1858,13 +1861,13 @@ class ButtonCard extends LitElement {
     // always returns the action in NORMALISED_ACTION for easier handling
     const localAction = this._evalActions(config, config[actionKey]);
 
-    if (localAction[NORMALISED_ACTION]?.protect?.pin !== undefined) {
+    if (localAction[NORMALISED_ACTION]?.protect?.pin) {
       (window as any).cardHelpers.showEnterCodeDialog(this, {
         submit: (code: string) => this._protectedConfirmedCallback.bind(this)(code, 'pin'),
         cancel: this._cancelledCallback.bind(this),
         codeFormat: 'number',
       });
-    } else if (localAction[NORMALISED_ACTION]?.protect?.password !== undefined) {
+    } else if (localAction[NORMALISED_ACTION]?.protect?.password) {
       (window as any).cardHelpers.showPromptDialog(this, {
         title: 'Password',
         inputLabel: 'Password',

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -54,6 +54,7 @@ export interface ButtonCardConfig {
   update_timer?: number;
   disable_kbd?: boolean;
   spinner?: boolean;
+  protect?: ButtonCardProtect;
 }
 
 export interface GridOptions {
@@ -110,6 +111,7 @@ export interface ExternalButtonCardConfig {
   update_timer?: number;
   disable_kbd?: boolean;
   spinner?: boolean;
+  protect?: ButtonCardProtect;
 }
 
 export type Layout =
@@ -202,6 +204,13 @@ export interface ButtonCardEmbeddedCardsConfig {
   [key: string]: string | undefined;
 }
 
+export interface ButtonCardProtect {
+  pin?: string;
+  password?: string;
+  failure_message?: string;
+  success_message?: string;
+}
+
 export interface ToggleActionConfig extends BaseActionConfig {
   action: 'toggle';
   entity?: string;
@@ -272,12 +281,7 @@ export interface BaseActionConfig {
   repeat_limit?: number;
   sound?: string;
   haptic?: 'light' | 'medium' | 'heavy' | 'selection' | 'success' | 'warning' | 'error' | 'none';
-  protect?: {
-    pin?: string;
-    password?: string;
-    failure_message?: string;
-    success_message?: string;
-  };
+  protect?: ButtonCardProtect;
 }
 
 export interface ConfirmationRestrictionConfig {

--- a/test/ui-lovelace.yaml
+++ b/test/ui-lovelace.yaml
@@ -1630,15 +1630,27 @@ views:
           - type: 'custom:button-card'
             icon: mdi:lock
             name: toggle password
+            show_label: true
+            label: 'tap: 1234<br/>hold: 0000<br/>dbltap: none'
+            protect:
+              password: '1234'
+              failure_message: 'Bad password!'
+              success_message: 'Yay! Access granted!'
             tap_action:
-              protect:
-                password: '1234'
-                failure_message: 'Bad password!'
-                success_message: 'Yay! Access granted!'
               action: perform-action
               perform_action: light.toggle
               data:
                 entity_id: light.test_light
+            hold_action:
+              protect:
+                password: '0000'
+              action: more-info
+              entity: light.test_light
+            double_tap_action:
+              protect:
+                password: ''
+              action: more-info
+              entity: switch.skylight
             section_mode: true
             grid_options:
               rows: 2


### PR DESCRIPTION
```yaml
type: custom:button-card
entity: light.aquarium
protect: # globally enables the PIN for all actions
  pin: '1234'
  success_message: 'PIN is correct!'
  failure_message: 'PIN is wrong!'
tap_action:
  action: toggle
hold_action:
  action: perform-action
  perform_action: switch.toggle
  target:
    entity_id: switch.aquarium_pump
icon_tap_action:
  action: more-info
  entity: sensor.aquarium_temperature
  protect:
    pin: '' # Setting this to an empty string disables the pin for this action only.
```

Closes #1044 