### PR TITLE
fix: improve spinner's default color for `color_type: card`

### DIFF
--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -1204,10 +1204,12 @@ class ButtonCard extends LitElement {
         cardStyle['background-color'] = color;
         cardStyle = { ...cardStyle, ...configCardStyle };
         buttonColor = 'inherit';
+        this.style.setProperty('--button-card-color', fontColor);
         break;
       }
       default:
         cardStyle = configCardStyle;
+        this.style.setProperty('--button-card-color', buttonColor);
         break;
     }
     if (this._config!.aspect_ratio) {
@@ -1222,7 +1224,6 @@ class ButtonCard extends LitElement {
       this._getColorForLightEntity(this._stateObj, false),
     );
     this.style.setProperty('--button-card-ripple-color', buttonColor);
-    this.style.setProperty('--button-card-color', buttonColor);
     lockStyle = { ...lockStyle, ...lockStyleFromConfig };
     spinnerStyle = { ...spinnerStyle, ...spinnerStyleFromConfig };
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -122,7 +122,6 @@ export const styles = css`
     top: 0;
     bottom: 0;
     display: flex;
-    /* --ha-spinner-size: 100%; */
   }
   #spinner-background {
     position: absolute;


### PR DESCRIPTION
Fixes #1058
