### PR TITLE
feat(ripple): `show_ripple` to disable or enable the ripple/hover effect (undefined = auto)

### DIFF
--- a/docs/source/config/main.md
+++ b/docs/source/config/main.md
@@ -20,6 +20,7 @@
 | `show_units` | :no_entry_sign: | boolean | `true` | `true` \| `false` | Display or hide the units of a sensor, if any. |
 | `show_label` | :no_entry_sign: | boolean | `false` | `true` \| `false` | Display or hide the `label` |
 | `show_last_changed` | :no_entry_sign: | boolean | `false` | `true` \| `false` | Replace the label altogether and display the the `last_changed` attribute in a nice way (eg: `12 minutes ago`) |
+| `show_ripple` | [:white_check_mark:](../advanced/js-templates.md) | boolean | optional | `true` or `false` | If defined, this will enable or disable the ripple/hover effect on the card. If undefined, the ripple/hover effect is automatically enabled if the card has at least an action defined (including the default one based on the entity). |
 | `show_entity_picture` | :no_entry_sign: | boolean | `false` | `true` \| `false` | Replace the icon by the entity picture (if any) or the custom picture (if any). Falls back to using the icon if both are undefined |
 | `show_live_stream` | :no_entry_sign: | boolean | `false` | `true` \| `false` | Display the camera stream (if the entity is a camera). Requires the `stream:` component to be enabled in home-assistant's config |
 | `live_stream_aspect_ratio` | :no_entry_sign: | string | optional | `16x9`, `50%`, `1.78` ... | See home-assistant Picture Entity card [aspect_ratio](https://www.home-assistant.io/dashboards/picture-entity/#aspect_ratio) for valid options |

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -1141,13 +1141,13 @@ class ButtonCard extends LitElement {
     const hasChildCards =
       this._hasChildCards(this._config!.custom_fields) ||
       !!(configState && this._hasChildCards(configState.custom_fields));
-
+    const rippleEnabled = this._getTemplateOrValue(state, this._config!.show_ripple);
     const cardHasActions = tapActive || holdActive || doubleTapActive || pressActive || releaseActive;
     this._cardClickable = cardHasActions || hasChildCards;
     this._hasIconActions =
       iconTapActive || iconHoldActive || iconDoubleTapActive || iconPressActive || iconReleaseActive;
     this._iconClickable = this._cardClickable || this._hasIconActions;
-    this._cardRipple = cardHasActions || this._hasIconActions;
+    this._cardRipple = rippleEnabled ?? (cardHasActions || this._hasIconActions);
     this._cardMomentary = pressActive || releaseActive;
     this._iconMomentary = iconPressActive || iconReleaseActive;
   }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -33,6 +33,7 @@ export interface ButtonCardConfig {
   show_last_changed?: boolean;
   show_label?: boolean;
   show_live_stream?: boolean;
+  show_ripple?: boolean;
   live_stream_aspect_ratio?: string;
   live_stream_fit_mode?: 'cover' | 'contain' | 'fill';
   label?: string;
@@ -93,6 +94,7 @@ export interface ExternalButtonCardConfig {
   show_last_changed?: boolean;
   show_label?: boolean;
   show_live_stream?: boolean;
+  show_ripple?: boolean;
   label?: string;
   entity_picture?: string;
   units?: string;

--- a/test/ui-lovelace.yaml
+++ b/test/ui-lovelace.yaml
@@ -2351,6 +2351,16 @@ views:
             grid_options:
               rows: 2
               columns: 4
+          - type: 'custom:button-card'
+            entity: switch.skylight
+            name: 'show_ripple:<br/>false'
+            show_ripple: false
+            tap_action:
+              action: toggle
+            section_mode: true
+            grid_options:
+              rows: 2
+              columns: 4
       - type: grid
         cards:
           - type: 'custom:button-card'


### PR DESCRIPTION
```yaml
type: 'custom:button-card'
entity: switch.skylight
name: 'show_ripple:<br/>false'
show_ripple: false
tap_action:
  action: toggle
section_mode: true
grid_options:
  rows: 2
  columns: 4
```