### PR TITLE
feat(custom_fields): New `force_recreate: true` to recreate the nested card on each config update

### DIFF
--- a/docs/source/advanced/custom-fields.md
+++ b/docs/source/advanced/custom-fields.md
@@ -151,9 +151,21 @@ custom_fields:
 
 ## Nested card
 
-Or you can embed a card (or multiple) inside the button card (note, this configuration uses [card-mod](https://github.com/thomasloven/lovelace-card-mod) to remove the `box-shadow` of the sensor card.
+Or you can embed a card (or multiple) inside the button card
 
-This is what the `style` inside the embedded card is for):
+!!! info
+
+    Some cards do not behave properly when their config is updated while already being displayed. In this case, you can set `force_recreate: true`. This will recreate the card every time there is an update. If you see weird behavior with nested cards (eg. not updating), try this setting.
+
+    ```yaml
+    type: custom:button-card
+    custom_fields:
+      graph:
+        force_recreate: true
+        card:
+          type: custom:decluttering-card
+          ...
+    ```
 
 ![custom_fields_3](../images/custom_fields_card.png)
 
@@ -166,7 +178,7 @@ custom_fields:
       type: sensor
       entity: sensor.sensor1
       graph: line
-      card_mod:
+      card_mod: # (1)!
         style: |
           ha-card {
             box-shadow: none;
@@ -182,11 +194,14 @@ styles:
     - grid-template-areas: '"i" "n" "graph"'
     - grid-template-columns: 1fr
     - grid-template-rows: 1fr min-content min-content
-
 entity: light.test_light
 hold_action:
   action: more-info
 ```
+
+1.  This configuration uses [card-mod](https://github.com/thomasloven/lovelace-card-mod) to remove the `box-shadow` of the sensor card.
+
+    This is what the `style` inside the embedded card is for.
 
 ## Nested cards with JS templates
 

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -1112,7 +1112,10 @@ class ButtonCard extends LitElement {
         };
         let thing;
         if (!deepEqual(this._cardsConfig[key], cards[key])) {
-          if ((this._cardsConfig[key] as any)?.type === cards[key]?.type) {
+          if (
+            (this._cardsConfig[key] as any)?.type === cards[key]?.type &&
+            (this._config!.custom_fields?.[key] as CustomFieldCard)?.force_recreate !== true
+          ) {
             // same type, different config
             thing = this._cards[key];
             thing.preview = this.preview;
@@ -1331,13 +1334,17 @@ class ButtonCard extends LitElement {
   private _getTooltip(tooltipStyle: StyleInfo, configState: StateConfig | undefined): TemplateResult {
     let tooltipConfig: TooltipConfig | undefined;
     if (typeof this._config!.tooltip === 'string') {
-      tooltipConfig = { content: this._getTemplateOrValue(this._stateObj, this._config!.tooltip) };
+      tooltipConfig = {
+        content: this._getTemplateOrValue(this._stateObj, this._config!.tooltip),
+      };
     } else {
       tooltipConfig = this._objectEvalTemplate(this._stateObj, this._config!.tooltip) ?? {};
     }
     let tooltipStateConfig: TooltipConfig | undefined;
     if (typeof configState?.tooltip === 'string') {
-      tooltipStateConfig = { content: this._getTemplateOrValue(this._stateObj, configState?.tooltip) };
+      tooltipStateConfig = {
+        content: this._getTemplateOrValue(this._stateObj, configState?.tooltip),
+      };
     } else {
       tooltipStateConfig = this._objectEvalTemplate(this._stateObj, configState?.tooltip) ?? {};
     }
@@ -2130,12 +2137,16 @@ class ButtonCard extends LitElement {
   private _protectedConfirmedCallback(code: string, type: 'pin' | 'password'): void {
     if (this._protectedAction && this._config) {
       if (code === this._protectedAction[NORMALISED_ACTION]?.protect?.[type]) {
-        this._sendToastMessage({ message: this._protectedAction[NORMALISED_ACTION]?.protect?.success_message });
+        this._sendToastMessage({
+          message: this._protectedAction[NORMALISED_ACTION]?.protect?.success_message,
+        });
         delete this._protectedAction[NORMALISED_ACTION]?.protect;
         this._executeAction(this._protectedAction);
       } else {
         const message = this._protectedAction[NORMALISED_ACTION]?.protect?.failure_message;
-        this._sendToastMessage({ message: message || DEFAULT_FAILED_TOAST_MESSAGE[type] });
+        this._sendToastMessage({
+          message: message || DEFAULT_FAILED_TOAST_MESSAGE[type],
+        });
       }
     }
     this._protectedAction = undefined;
@@ -2223,7 +2234,12 @@ class ButtonCard extends LitElement {
     ev.stopPropagation();
     this.parentElement?.dispatchEvent(event);
     // Send non-bubbling event to ha-card to allow ripples
-    const rippleEvent = new CustomEvent(ev.type, { ...ev, bubbles: false, composed: false, detail: { ignore: true } });
+    const rippleEvent = new CustomEvent(ev.type, {
+      ...ev,
+      bubbles: false,
+      composed: false,
+      detail: { ignore: true },
+    });
     this._ripple.then((r) => {
       if (r) {
         r.parentElement?.dispatchEvent(rippleEvent);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -194,6 +194,7 @@ export interface CustomFields {
 export interface CustomFieldCard {
   card: LovelaceCardConfig;
   do_not_eval?: boolean;
+  force_recreate?: boolean;
 }
 
 export interface Variables {


### PR DESCRIPTION
Some cards do not behave properly when their config is updated while already being displayed. In this case, you can set `force_recreate: true`. This will recreate the card every time there is an update. If you see weird behavior with nested cards (eg. not updating), try this setting.

```yaml
type: custom:button-card
custom_fields:
  graph:
    force_recreate: true
    card:
      type: custom:decluttering-card
      ...
```

Fixes #1086