### PR TITLE
fix: Fix custom element does not exist error which may arise under specific circumstances

### DIFF
--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -1113,7 +1113,18 @@ class ButtonCard extends LitElement {
           'grid-area': key,
         };
         let thing;
-        if (!deepEqual(this._cardsConfig[key], cards[key])) {
+        if (
+          (this._cards[key] as any)?.type === 'error' &&
+          (this._cards[key] as any)?.error?.includes("Element doesn't exist") &&
+          cards[key]?.type !== 'error' &&
+          customElements.get(cards[key]?.type)
+        ) {
+          // previously errored because element didn't exist, but now it does
+          thing = this._createCard(cards[key]);
+          thing.preview = this.preview;
+          this._cards[key] = thing;
+          this._cardsConfig[key] = copy(cards[key]);
+        } else if (!deepEqual(this._cardsConfig[key], cards[key])) {
           if (
             (this._cardsConfig[key] as any)?.type === cards[key]?.type &&
             (this._config!.custom_fields?.[key] as CustomFieldCard)?.force_recreate !== true

--- a/src/common/create-thing.ts
+++ b/src/common/create-thing.ts
@@ -81,13 +81,17 @@ export const createThing = (cardConfig, isRow = false) => {
   if (customElements.get(tag)) return _createThing(tag, cardConfig);
 
   // If element doesn't exist (yet) create an error
-  const element = _createError(`Custom element doesn't exist: ${cardConfig.type}.`, cardConfig);
+  const element = _createError(`Element doesn't exist: ${cardConfig.type}.`, cardConfig);
   element.style.display = 'None';
   const timer = setTimeout(() => {
     element.style.display = '';
   }, 2000);
   // Remove error if element is defined later
-  customElements.whenDefined(cardConfig.type).then(() => {
+  // We will get here if cardHelpers were not initially available
+  // and we are the first to load the lazy loaded element
+  // as createCardElement in cardHelpers does not await the lazy loaded import
+  // before trying to create the element.
+  customElements.whenDefined(tag).then(() => {
     clearTimeout(timer);
     fireEvent(element, 'll-rebuild', {}, element);
   });


### PR DESCRIPTION
Fixes #1150 

This is hard to replicate. To do so I set the initial values of helpers to undefined and then delayed calling the helperPromise in _createCard. Even then it only happens for me 1 out of 10 or so.

This PR may not be the best way. The crux of the matter is that Frontend does not await import of lazy loaded stock cards like it does for dialogs. Perhaps createThing is not needed anymore and solely rely on createCardElement and only show 'Loading...' while cardHelpers are not defined, allowing the recovery logic in createCardElement to handle the lazy loading, which it does, including recovering from not awaiting the import.

The PR as is provides for least risk as far as changes to button-card. However I am happy to look for alternatives. Two in mind:

1. Use createCardElemenet only and warp in a promise to allow for cardHelpers not to be available, and use `${until(thing), "Loading..."}` or
2. Switch over to load cards via hui-card method where everything is abstracted to Frontend. e.g. as per my [update to auto-entities](https://github.com/thomasloven/lovelace-auto-entities/pull/591/changes#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR186). Similar method used with expander-card. The only caveat here is the extra `hui-card` wrapper which may break card-mod config users have, and perhaps other things I have not thought of.

PR in draft to allow for discussion. 