### PR TITLE
feat(JS): Add device name, area name and entity name JS helpers

### DIFF
--- a/docs/source/advanced/js-templates.md
+++ b/docs/source/advanced/js-templates.md
@@ -98,6 +98,10 @@ Inside the javascript code, you'll have access to those variables:
   - `helpers.parseDuration(duration,format?='ms',locale? = <Home Assistant locale>)`: Parses a string duration to number. `helpers.parseDuration('1 day', 's')` returns `86400`. `helpers.parseDuration('1 jour', 'd', 'fr')` returns `1`. If a locale is specified `en` is also used as a fallback.
   - `helpers.toastMessage(message)` and `helpers.toast(toastParams)`: See [toast helpers](../config/actions.md#toast-helpers)
   - `helpers.runAction(actionConfig)`: See [`runAction` JS helper](../config/actions.md#runaction-js-helper)
+  - Helpers to retrieve an entity name, area name or device name:
+    - `helpers.getEntityName(entityId)`: returns the name of the entity. It uses the `friendly_name` attribute if it exists, else it returns the entity part of the entity_id.
+    - `helpers.getDeviceNameFromEntityId(entityId)`: returns the name of the device of the entity if the entity is linked to a device, else it returns `undefined`.
+    - `helpers.getAreaNameFromEntityId(entityId)`: returns the name of the area of the entity if the entity is in an area, else it returns the area of the device if the entity is linked to a device which is in an area, else it returns `undefined`.
 
 See [here](../examples/js-templates.md) for some examples or [here](./custom-fields.md) for some advanced configuration using templates.
 

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -758,6 +758,27 @@ class ButtonCard extends LitElement {
         const localAction = this._evalActions(this._config!, actionConfig);
         this._buildActionConfig(localAction);
       },
+      // Name formating
+      getEntityName: (entityId: string) => {
+        return (
+          this._hass!.entities?.[entityId]?.name ||
+          this._hass!.states?.[entityId]?.attributes?.friendly_name ||
+          computeEntity(entityId)
+        );
+      },
+      getDeviceNameFromEntityId: (entityId: string) => {
+        return this._hass!.devices?.[this._hass!.entities?.[entityId]?.device_id || '']?.name || undefined;
+      },
+      getAreaNameFromEntityId: (entityId: string) => {
+        const entityAreaId = this._hass!.entities?.[entityId]?.area_id;
+        const deviceAreaId = this._hass!.devices?.[this._hass!.entities?.[entityId]?.device_id || '']?.area_id;
+        if (entityAreaId) {
+          return this._hass!.areas?.[entityAreaId]?.name;
+        } else if (deviceAreaId) {
+          return this._hass!.areas?.[deviceAreaId].name;
+        }
+        return undefined;
+      },
     };
   }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -18,11 +18,11 @@ export const atLeastVersion = (version: string, major: number, minor: number): b
 };
 
 export function computeDomain(entityId: string): string {
-  return entityId.substr(0, entityId.indexOf('.'));
+  return entityId.slice(0, entityId.indexOf('.'));
 }
 
 export function computeEntity(entityId: string): string {
-  return entityId.substr(entityId.indexOf('.') + 1);
+  return entityId.slice(entityId.indexOf('.') + 1);
 }
 
 export const computeStateDomain = (stateObj: HassEntity) => computeDomain(stateObj.entity_id);


### PR DESCRIPTION
This pull request introduces new helper functions to retrieve entity, device, and area names in JavaScript templates, and makes a minor improvement to string handling in helper functions. The main focus is on enhancing the developer experience by providing easier access to entity-related names.

**New helper functions for entity, device, and area names:**

* Added `getEntityName(entityId)` to return the friendly name or entity part of the `entity_id` (`src/button-card.ts`, `docs/source/advanced/js-templates.md`) [[1]](diffhunk://#diff-a52ea2eb903aabe416ffb95dfd846a11a2f752250a95b43e289df465a4d56aeaR761-R781) [[2]](diffhunk://#diff-60ad665cf0c22cf58334e4c9ce83526fddd280cca53c8ad9dc93fb16dff5df68R101-R104)
* Added `getDeviceNameFromEntityId(entityId)` to return the device name linked to an entity, or `undefined` if not available (`src/button-card.ts`, `docs/source/advanced/js-templates.md`) [[1]](diffhunk://#diff-a52ea2eb903aabe416ffb95dfd846a11a2f752250a95b43e289df465a4d56aeaR761-R781) [[2]](diffhunk://#diff-60ad665cf0c22cf58334e4c9ce83526fddd280cca53c8ad9dc93fb16dff5df68R101-R104)
* Added `getAreaNameFromEntityId(entityId)` to return the area name for an entity or its device, or `undefined` if not available (`src/button-card.ts`, `docs/source/advanced/js-templates.md`) [[1]](diffhunk://#diff-a52ea2eb903aabe416ffb95dfd846a11a2f752250a95b43e289df465a4d56aeaR761-R781) [[2]](diffhunk://#diff-60ad665cf0c22cf58334e4c9ce83526fddd280cca53c8ad9dc93fb16dff5df68R101-R104)

**Documentation updates:**

* Documented the new helpers in the JavaScript templates documentation (`docs/source/advanced/js-templates.md`)

**Code quality improvement:**

* Replaced `substr` with `slice` in `computeDomain` and `computeEntity` for better string handling (`src/helpers.ts`)

Fixes #1164 