### PR TITLE
feat(custom_fields): The whole custom_field object and the associated custom_field style object can now be a JS Template

### DIFF
--- a/docs/source/advanced/custom-fields.md
+++ b/docs/source/advanced/custom-fields.md
@@ -240,3 +240,74 @@ custom_fields:
 2. This will return: B: undefined / C: 42 as it is evaluated in the context of the local button-card inside the custom_field (which doesn't know about b)
 3. (**DEPRECATED**) This stops the evaluation of js templates for the card object in this custom field
 4. This will return: B: undefined / C: 42 as it is evaluated in the context of the local button-card inside the custom_field (which doesn't know about b)
+
+## Custom Fields as JS Templates
+
+You can also set the whole `custom_fields` object as a [JS template](./js-templates.md), this allows you to create custom fields dynamically based on the state of an entity or whatever you want.
+
+If you want to apply styles to them as well, you can also set the `styles.custom_fields` as a [JS template](./js-templates.md) that returns an object with the same keys as the custom fields and the styles you want to apply to them.
+
+This is useful if you want to show/hide custom fields based on the state of an entity, or if you want to change the card inside a custom field based on the state of an entity, etc...
+
+```yaml
+type: custom:button-card
+name: |
+  <b>Custom Fields as a JS Template.</b> <br/>
+  Shows a red background and a markdown card if sensor1 is 0 <br/>
+  Shows a blue background with an entity card if it's above 0.
+variables:
+  card1:
+    card:
+      type: markdown
+      content: 'This is a custom field with a markdown card'
+  card2:
+    card:
+      type: entity
+      entity: sensor.sensor1
+custom_fields: |
+  [[[
+    if (hass.states["sensor.sensor1"].state == 0) {
+      return {
+        test: variables.card1,
+      }
+    } else {
+      return {
+        test: variables.card2,
+      }
+    }
+  ]]]
+styles:
+  grid:
+    - grid-template-areas: '"n" "test"'
+    - grid-template-columns: 1fr
+    - grid-template-rows: min-content 1fr
+  custom_fields: |
+    [[[
+      return {
+        test: [
+          { 'background-color': 'blue' },
+          { padding: '10px' },
+          { 'border-radius': '10px' },
+        ],
+      }
+    ]]]
+state:
+  - value: '[[[ return hass.states["sensor.sensor1"].state > 0 ]]]'
+    operator: template
+    styles:
+      custom_fields: |
+        [[[
+          return {
+            test: [
+              { 'background-color': 'green' },
+              { padding: '20px' },
+            ],
+          }
+        ]]]
+  - value: '[[[ return hass.states["sensor.sensor1"].state == 0 ]]]'
+    operator: template
+    styles:
+      custom_fields:
+        test:
+          - background-color: red
+```

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -951,29 +951,6 @@ class ButtonCard extends LitElement {
     return style;
   }
 
-  private _buildCustomStyleGeneric(
-    state: HassEntity | undefined,
-    configState: StateConfig | undefined,
-    styleType: string,
-  ): StyleInfo {
-    let style: any = {};
-    if (this._config!.styles?.custom_fields?.[styleType]) {
-      style = Object.assign(style, ...this._config!.styles.custom_fields[styleType]);
-    }
-    if (configState?.styles?.custom_fields?.[styleType]) {
-      let configStateStyle: StyleInfo = {};
-      configStateStyle = Object.assign(configStateStyle, ...configState.styles.custom_fields[styleType]);
-      style = {
-        ...style,
-        ...configStateStyle,
-      };
-    }
-    Object.keys(style).forEach((key) => {
-      style[key] = this._getTemplateOrValue(state, style[key]);
-    });
-    return style;
-  }
-
   private _buildName(state: HassEntity | undefined, configState: StateConfig | undefined): string | undefined {
     if (this._config!.show_name === false) {
       return undefined;

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -1066,40 +1066,34 @@ class ButtonCard extends LitElement {
     let result = html``;
     const fields: any = {};
     const cards: any = {};
-    if (this._config!.custom_fields) {
-      Object.keys(this._config!.custom_fields).forEach((key) => {
-        const value = this._config!.custom_fields![key];
-        if (!(value as CustomFieldCard).card) {
-          fields[key] = this._getTemplateOrValue(state, value);
+
+    [this._config!.custom_fields, configState?.custom_fields].forEach((customFields) => {
+      if (customFields) {
+        if (typeof customFields === 'string') {
+          this._buildCustomFieldsFromString(customFields, state, fields, cards);
         } else {
-          if ((value as CustomFieldCard).do_not_eval) {
-            cards[key] = copy((value as CustomFieldCard).card);
-          } else {
-            cards[key] = this._objectEvalTemplate(state, (value as CustomFieldCard).card);
-          }
+          this._buildCustomFieldFromObject(customFields, state, fields, cards);
         }
-      });
-    }
-    if (configState?.custom_fields) {
-      Object.keys(configState.custom_fields).forEach((key) => {
-        const value = configState!.custom_fields![key];
-        if (!(value as CustomFieldCard)!.card) {
-          fields[key] = this._getTemplateOrValue(state, value);
-        } else {
-          if ((value as CustomFieldCard).do_not_eval) {
-            cards[key] = copy((value as CustomFieldCard).card);
-          } else {
-            cards[key] = this._objectEvalTemplate(state, (value as CustomFieldCard).card);
-          }
-        }
-      });
-    }
+      }
+    });
+
+    let mainCustomStyles: any = {};
+    [this._config!.styles?.custom_fields, configState?.styles?.custom_fields].forEach((customFieldStyles) => {
+      if (customFieldStyles) {
+        mainCustomStyles = mergeDeep(mainCustomStyles, this._objectEvalTemplate(state, customFieldStyles));
+      }
+    });
+
     Object.keys(fields).forEach((key) => {
       if (fields[key] != undefined) {
-        const customStyle: StyleInfo = {
-          ...this._buildCustomStyleGeneric(state, configState, key),
-          'grid-area': key,
-        };
+        const customStyle: StyleInfo = mainCustomStyles?.[key]
+          ? {
+              ...Object.assign({}, ...mainCustomStyles[key]),
+              'grid-area': key,
+            }
+          : {
+              'grid-area': key,
+            };
         result = html`
           ${result}
           <div id=${key} class="ellipsis" style=${styleMap(customStyle)}>${this._unsafeHTMLorNot(fields[key])}</div>
@@ -1108,10 +1102,14 @@ class ButtonCard extends LitElement {
     });
     Object.keys(cards).forEach((key) => {
       if (cards[key] != undefined) {
-        const customStyle: StyleInfo = {
-          ...this._buildCustomStyleGeneric(state, configState, key),
-          'grid-area': key,
-        };
+        const customStyle: StyleInfo = mainCustomStyles?.[key]
+          ? {
+              ...Object.assign({}, ...mainCustomStyles[key]),
+              'grid-area': key,
+            }
+          : {
+              'grid-area': key,
+            };
         let thing;
         if (!deepEqual(this._cardsConfig[key], cards[key])) {
           if (
@@ -1154,8 +1152,54 @@ class ButtonCard extends LitElement {
     return result;
   }
 
-  private _hasChildCards(customFields: CustomFields | undefined): boolean {
+  // updates fields and cards in place
+  private _buildCustomFieldFromObject(
+    customFieldObj: CustomFields | undefined,
+    state: HassEntity | undefined,
+    fields: any,
+    cards: any,
+  ): void {
+    if (!customFieldObj) return;
+    Object.keys(customFieldObj).forEach((key) => {
+      const value = customFieldObj[key];
+      if (!(value as CustomFieldCard).card) {
+        fields[key] = this._getTemplateOrValue(state, value);
+      } else {
+        if ((value as CustomFieldCard).do_not_eval) {
+          cards[key] = copy((value as CustomFieldCard).card);
+        } else {
+          cards[key] = this._objectEvalTemplate(state, (value as CustomFieldCard).card);
+        }
+      }
+    });
+  }
+
+  private _buildCustomFieldsFromString(
+    customFieldsString: string | undefined,
+    state: HassEntity | undefined,
+    fields: any,
+    cards: any,
+  ): void {
+    const evaled = this._getTemplateOrValue(state, customFieldsString);
+    if (!evaled) {
+      return;
+    } else if (typeof evaled === 'object') {
+      Object.keys(evaled).forEach((key) => {
+        const value = evaled[key];
+        if (!(value as CustomFieldCard).card) {
+          fields[key] = value;
+        } else {
+          cards[key] = value.card;
+        }
+      });
+    } else {
+      throw new Error('button-card: custom_fields template did not evaluate to an object');
+    }
+  }
+
+  private _hasChildCards(customFields: string | CustomFields | undefined): boolean {
     if (!customFields) return false;
+    if (typeof customFields === 'string') return true; // we assume that if it's a string, it will evaluate to an object with cards or fields
     return Object.keys(customFields).some((key) => {
       const value = customFields![key];
       if ((value as CustomFieldCard)!.card) {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -45,7 +45,7 @@ export interface ButtonCardConfig {
   confirmation?: string;
   layout: Layout;
   entity_picture_style?: CssStyleConfig[];
-  custom_fields?: CustomFields;
+  custom_fields?: CustomFields | string;
   variables?: Variables;
   extra_styles?: string;
   card_size: number;
@@ -103,7 +103,7 @@ export interface ExternalButtonCardConfig {
   confirmation?: string;
   layout?: Layout;
   entity_picture_style?: CssStyleConfig[];
-  custom_fields?: CustomFields;
+  custom_fields?: CustomFields | string;
   variables?: Variables;
   extra_styles?: string;
   card_size?: number;
@@ -160,7 +160,7 @@ export interface StateConfig {
   styles?: StylesConfig;
   rotate?: boolean;
   label?: string;
-  custom_fields?: CustomFields;
+  custom_fields?: CustomFields | string;
   state_display?: string;
   spinner?: boolean;
   tooltip?: string | TooltipConfig;
@@ -177,7 +177,7 @@ export interface StylesConfig {
   img_cell?: CssStyleConfig[];
   lock?: CssStyleConfig[];
   tooltip?: CssStyleConfig[];
-  custom_fields?: CustomStyleConfig;
+  custom_fields?: CustomStyleConfig | string;
 }
 
 export interface CustomStyleConfig {

--- a/test/lovelace/09_custom_fields.yaml
+++ b/test/lovelace/09_custom_fields.yaml
@@ -1,6 +1,67 @@
 title: Custom Fields
 cards:
   - type: custom:button-card
+    name: |
+      <b>Custom Fields as a JS Template.</b> <br/>
+      Shows a red background and a markdown card if sensor1 is 0 <br/>
+      Shows a blue background with an entity card if it's above 0.
+    variables:
+      card1:
+        card:
+          type: markdown
+          content: 'This is a custom field with a markdown card'
+      card2:
+        card:
+          type: entity
+          entity: sensor.sensor1
+    custom_fields: |
+      [[[
+        if (hass.states["sensor.sensor1"].state == 0) {
+          return {
+            test: variables.card1,
+          }
+        } else {
+          return {
+            test: variables.card2,
+          }
+        }
+      ]]]
+    styles:
+      grid:
+        - grid-template-areas: '"n" "test"'
+        - grid-template-columns: 1fr
+        - grid-template-rows: min-content 1fr
+      custom_fields: |
+        [[[
+          return {
+            test: [
+              { 'background-color': 'blue' },
+              { padding: '10px' },
+              { 'border-radius': '10px' },
+            ],
+          }
+        ]]]
+    state:
+      - value: '[[[ return hass.states["sensor.sensor1"].state > 0 ]]]'
+        operator: template
+        styles:
+          custom_fields: |
+            [[[
+              return {
+                test: [
+                  { 'background-color': 'green' },
+                  { padding: '20px' },
+                ],
+              }
+            ]]]
+      - value: '[[[ return hass.states["sensor.sensor1"].state == 0 ]]]'
+        operator: template
+        styles:
+          custom_fields:
+            test:
+              - background-color: red
+
+  - type: custom:button-card
     variables:
       test2: piou
     template: test_var


### PR DESCRIPTION
This pull request adds support for defining `custom_fields` and their styles as JavaScript templates, making it possible to dynamically generate custom fields and their appearance based on entity state or other logic. The implementation updates both the code and documentation, and includes a new test case to demonstrate the feature.

**Dynamic custom fields and styles:**

* [`src/types/types.ts`](diffhunk://#diff-11e9171ff36dfa6e6b396909ac6b924cf79337d5f05a7eaa15f78a9b2e2eded6L48-R48): Updated the types for `custom_fields` and `styles.custom_fields` in `ButtonCardConfig`, `ExternalButtonCardConfig`, `StateConfig`, and `StylesConfig` to accept either an object or a string (JS template). [[1]](diffhunk://#diff-11e9171ff36dfa6e6b396909ac6b924cf79337d5f05a7eaa15f78a9b2e2eded6L48-R48) [[2]](diffhunk://#diff-11e9171ff36dfa6e6b396909ac6b924cf79337d5f05a7eaa15f78a9b2e2eded6L106-R106) [[3]](diffhunk://#diff-11e9171ff36dfa6e6b396909ac6b924cf79337d5f05a7eaa15f78a9b2e2eded6L163-R163) [[4]](diffhunk://#diff-11e9171ff36dfa6e6b396909ac6b924cf79337d5f05a7eaa15f78a9b2e2eded6L180-R180)
* [`src/button-card.ts`](diffhunk://#diff-a52ea2eb903aabe416ffb95dfd846a11a2f752250a95b43e289df465a4d56aeaL1069-R1094): Refactored the logic in the `ButtonCard` class to support evaluating `custom_fields` and `styles.custom_fields` as JS templates, including new helper methods for handling both string (template) and object cases. Styles are now merged and applied dynamically based on the evaluated templates. [[1]](diffhunk://#diff-a52ea2eb903aabe416ffb95dfd846a11a2f752250a95b43e289df465a4d56aeaL1069-R1094) [[2]](diffhunk://#diff-a52ea2eb903aabe416ffb95dfd846a11a2f752250a95b43e289df465a4d56aeaL1111-R1110) [[3]](diffhunk://#diff-a52ea2eb903aabe416ffb95dfd846a11a2f752250a95b43e289df465a4d56aeaL1157-R1202)

**Documentation:**

* [`docs/source/advanced/custom-fields.md`](diffhunk://#diff-e55fc0ad482dbd0aa2872857970fa4d72f8cba15435fa77db2d685644fb91e88R243-R313): Added a new section explaining how to use JS templates for `custom_fields` and their styles, including an example YAML configuration.

**Testing:**

* [`test/lovelace/09_custom_fields.yaml`](diffhunk://#diff-877ec40b4fdbeec94660412eb4fc929ba5c43d231ad74cba867ddd2a7472f01dR3-R63): Added a test case demonstrating the use of `custom_fields` and `styles.custom_fields` as JS templates, with dynamic behavior based on the state of `sensor1`.

Fixes #1154