### PR TITLE
feat: add the possibility to load configuration templates from URLs

### DIFF
--- a/docs/source/advanced/config-templates.md
+++ b/docs/source/advanced/config-templates.md
@@ -17,11 +17,31 @@
 
 Make sure which type of lovelace dashboard you are using before changing the main lovelace configuration:
 
-- **`managed`** changes are managed by lovelace ui: add the template configuration to configuration in raw editor
-  - go to your dashboard
-  - click three dots and `Edit dashboard` button
-  - click three dots again and click `Raw configuration editor` button
-- **`yaml`**: add template configuration to your `ui-lovelace.yaml`
+- **`managed`** changes are managed by lovelace ui: add the template configuration to the dashboard in the RAW editor.
+
+      - go to your dashboard
+      - click the three dots and `Edit dashboard` button
+      - click the three dots again and click `Raw configuration editor` button
+      - Add your template configuration at the top of the file, before the `views` key
+
+- **`yaml`**: add your template configuration to your `ui-lovelace.yaml` file, before the `views` key
+
+Then you can define your templates in 2 ways:
+
+- Defined directly in the [dashboard configuration](#loading-templates-directly-defined-in-the-dashboard)
+- Loaded from a [URL](#loading-templates-from-a-url)
+
+### Loading templates directly defined in the dashboard
+
+!!! info
+
+    If you are in YAML mode, you can use Home Assistant's YAML extensions `!include`, `!include_dir_named` or `!include_dir_merge_named` to split your templates in multiple files. For example, you can create a file `templates.yaml` and include it in your main configuration as follows:
+
+    ```yaml
+    button_card_templates: !include templates.yaml
+    ```
+
+This would be the content of your lovelace dashboard file (either in the RAW editor of your dashboard if you are in `managed` mode or in your `ui-lovelace.yaml` file if you are in `yaml` mode):
 
 ```yaml
 button_card_templates:
@@ -48,15 +68,68 @@ button_card_templates:
         - background-color: '#FF0000'
 
   my_little_template: [...]
+
+views:
+  - title: My view
+  # ...
 ```
 
-And then you can apply this template, and/or overload it:
+### Loading templates files from a URL
+
+!!! warning "Security Warning"
+
+    By using this feature, you are trusting the source of the URL. Make sure you trust the source and do not blindly load templates from unknown sources as they can contain malicious code. Always review the content of the URL before using it.
+
+You can load templates from a URL using `button_card_templates_url`. This is useful if you want to share your templates between multiple dashboards when they are managed by Home Assistant (i.e., not in yaml mode) or if you want to load templates from an external source.
+
+The only requirement is that the URL returns a valid YAML with the same structure as the `button_card_templates` configuration.
+
+Any valid URL is supported:
+
+- **local files**: eg. `/local/my_templates.yaml` which would download the file `/config/www/my_templates.yaml` located on your Home Assistant's server
+- **external URLs**: eg. `https://example.com/my_templates.yaml`.
+
+!!! info
+
+    - None of the Home Assistant's YAML extensions are supported in the file loaded from the URL. This means that you cannot use `!include` or any other Home Assistant's YAML extension in a file loaded from a URL. You can still use YAML anchors and aliases as they are part of the YAML specification.
+    - If a template is defined both in `button_card_templates` and in file loaded from `button_card_templates_url`, the one defined in `button_card_templates` will take precedence over the one loaded from the URL.
+    - If a template is defined in multiple files loaded from `button_card_templates_url`, the one defined in the last file will take precedence over the previous ones. The order of the files is determined by the order they are defined in the `button_card_templates_url` array.
+    - Each URL will be loaded by all the `custom:button-card` displayed on the page. There's only so much we can do to optimize this behavior.
+    - This might slow down the loading of your dashboard if the URL is slow to respond.
+
+```yaml
+button_card_templates_url:
+  - /local/my_templates.yaml
+  - https://example.com/my_templates.yaml
+
+views:
+  - title: My view
+  # ...
+```
+
+## Using config templates in a button-card
+
+Once you have defined your template, you can use it in your button-card as follows:
 
 ```yaml
 type: custom:button-card
 template: header_red
 name: My Test Header
 ```
+
+Or you can also inherit multiple templates at once by making it an array:
+
+```yaml
+type: custom:button-card
+template:
+  - template1
+  - template2
+name: Testing multiple templates
+```
+
+In this case, the templates will be merged together with the current configuration in the order they are defined: `template2` will be merged with `template1` and then the local config will be merged with the result. You can still chain templates together (ie. define template in a button-card template. It will follow the path recursively).
+
+Merging means that the last defined parameter will overwrite the previous one. For example, if `template1` defines a `color: red` and `template2` defines a `color: blue`, the resulting color will be `blue`. If the local config also defines a `color: green`, the final color will be `green`.
 
 ## Merging state by id
 

--- a/docs/source/advanced/config-templates.md
+++ b/docs/source/advanced/config-templates.md
@@ -29,7 +29,7 @@ Make sure which type of lovelace dashboard you are using before changing the mai
 Then you can define your templates in 2 ways:
 
 - Defined directly in the [dashboard configuration](#loading-templates-directly-defined-in-the-dashboard)
-- Loaded from a [URL](#loading-templates-from-a-url)
+- Loaded from a [URL](#loading-templates-files-from-a-url)
 
 ### Loading templates directly defined in the dashboard
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "lit-element": "^4.2.2",
     "lit-html": "^3.3.2",
     "memoize-one": "^6.0.0",
-    "parse-duration": "^2.1.6"
+    "parse-duration": "^2.1.6",
+    "yaml": "^2.8.3"
   }
 }

--- a/src/button-card.ts
+++ b/src/button-card.ts
@@ -108,6 +108,7 @@ import {
 } from './common/format_date';
 import { parseDuration } from './common/parse-duration';
 import { forwardHaptic, HapticType } from './forward-haptic';
+import YAML from 'yaml';
 
 let helpers = (window as any).cardHelpers;
 const helperPromise = new Promise<void>(async (resolve) => {
@@ -134,6 +135,8 @@ console.info(
   'color: orange; font-weight: bold; background: black',
   'color: white; font-weight: bold; background: dimgray',
 );
+
+const templateCache: Record<string, any> = {};
 
 (window as any).customCards = (window as any).customCards || [];
 (window as any).customCards.push({
@@ -1678,7 +1681,49 @@ class ButtonCard extends LitElement {
     }
   }
 
-  private _configFromLLTemplates(ll: any, config: any): ExternalButtonCardConfig {
+  private async _configFromTemplates(ll: any, config: any): Promise<ExternalButtonCardConfig> {
+    const tpl = config.template;
+    let result: any = {};
+    if (!tpl) {
+      result = copy(config);
+    } else {
+      let urlTemplates: any = {};
+      if (ll.config.button_card_templates_url) {
+        const urls = Array.isArray(ll.config.button_card_templates_url)
+          ? ll.config.button_card_templates_url
+          : [ll.config.button_card_templates_url];
+        for (const templateUrl of urls) {
+          try {
+            if (templateCache[templateUrl]) {
+              urlTemplates = { ...urlTemplates, ...templateCache[templateUrl] };
+            } else {
+              const response = await fetch(templateUrl, { cache: 'no-cache' });
+              if (!response.ok) {
+                throw new Error(`HTTP error! Status: ${response.status}`);
+              }
+              const blob = await response.blob();
+              const text = await blob.text();
+              const parsedTemplates = YAML.parse(text);
+              urlTemplates = { ...urlTemplates, ...parsedTemplates };
+              templateCache[templateUrl] = parsedTemplates;
+            }
+          } catch (error: any) {
+            throw new Error(`Error loading button-card template from URL '${templateUrl}': ${error}`);
+          }
+        }
+      }
+      const configTemplates = copy(ll.config.button_card_templates) as any;
+      const allTemplates = { ...urlTemplates, ...configTemplates };
+      result = this._configFromLLTemplates(allTemplates, config);
+    }
+    if (result.extra_styles) {
+      this._extraStyles?.push(result.extra_styles);
+      delete result.extra_styles;
+    }
+    return result as ExternalButtonCardConfig;
+  }
+
+  private _configFromLLTemplates(templates: any, config: any): ExternalButtonCardConfig {
     const tpl = config.template;
     let result: any = {};
     if (!tpl) {
@@ -1687,9 +1732,8 @@ class ButtonCard extends LitElement {
       let mergedStateConfig: StateConfig[] | undefined;
       const tpls = tpl && Array.isArray(tpl) ? tpl : [tpl];
       tpls?.forEach((template) => {
-        if (!ll.config.button_card_templates?.[template])
-          throw new Error(`Button-card template '${template}' is missing!`);
-        const res = this._configFromLLTemplates(ll, ll.config.button_card_templates[template]);
+        if (!templates?.[template]) throw new Error(`Button-card template '${template}' is missing!`);
+        const res = this._configFromLLTemplates(templates, templates[template]);
         result = mergeDeep(result, res);
         mergedStateConfig = mergeStatesById(mergedStateConfig, res.state);
       });
@@ -1703,7 +1747,7 @@ class ButtonCard extends LitElement {
     return result as ExternalButtonCardConfig;
   }
 
-  public setConfig(config: ExternalButtonCardConfig): void {
+  public async setConfig(config: ExternalButtonCardConfig): Promise<void> {
     if (!config) {
       throw new Error('Invalid configuration');
     }
@@ -1716,7 +1760,7 @@ class ButtonCard extends LitElement {
     this._extraStyles = [];
     const ll = getLovelace() || getLovelaceCast();
     let template: ExternalButtonCardConfig = copy(config);
-    template = this._configFromLLTemplates(ll, template);
+    template = await this._configFromTemplates(ll, template);
     this._config = {
       type: 'custom:button-card',
       group_expand: false,

--- a/test/button-card-templates.yaml
+++ b/test/button-card-templates.yaml
@@ -331,3 +331,37 @@ extraS3:
         color: ${entity.state === 'on' ? 'green' : 'purple'};
       }`;
     ]]]
+
+label_bold:
+  show_label: true
+  label: |
+    [[[
+      return variables.test_result ? "Pass" : "Fail";
+    ]]]
+  styles:
+    label:
+      - font-weight: bold
+      - color: '[[[ return variables.test_result ? "green" : "red"; ]]]'
+      - padding-top: 10px
+
+simple_template:
+  template:
+    - label_bold
+  styles:
+    icon:
+      - color: blue
+
+simple_template_override:
+  template:
+    - label_bold
+  styles:
+    icon:
+      - color: blue
+
+nested_templates:
+  template:
+    - label_bold
+    - simple_template
+  styles:
+    name:
+      - color: blue

--- a/test/lovelace/10_config_templates.yaml
+++ b/test/lovelace/10_config_templates.yaml
@@ -1,0 +1,42 @@
+title: Config Templates
+cards:
+  - type: grid
+    columns: 2
+    cards:
+      - type: custom:button-card
+        name: Simple Template (icon blue)
+        template: simple_template
+        show_label: true
+        variables:
+          test_result: "[[[ return this._config.styles?.icon?.[0]?.color === 'blue' ]]]"
+        section_mode: true
+        icon: mdi:fire
+
+      - type: custom:button-card
+        name: Simple Template from URL<br/>(icon green)
+        template: simple_template_url
+        show_label: true
+        variables:
+          test_result: "[[[ return this._config.styles?.icon?.[0]?.color === 'green' ]]]"
+        section_mode: true
+        icon: mdi:fire
+
+      - type: custom:button-card
+        name: Local Template (icon blue)<br/>overrides URL Template<br/>(icon green)
+        template: simple_template_override
+        show_label: true
+        variables:
+          test_result: "[[[ return this._config.styles?.icon?.[0]?.color === 'blue' ]]]"
+        section_mode: true
+        icon: mdi:fire
+
+      - type: custom:button-card
+        name: Nested Templates<br/>icon red and name red
+        template: nested_templates
+        show_label: true
+        variables:
+          test_result: |
+            [[[ return this._config.styles?.icon?.[0]?.color === 'blue'
+            && this._config.styles?.name?.[0]?.color === 'blue' ]]]
+        section_mode: true
+        icon: mdi:fire

--- a/test/ui-lovelace.yaml
+++ b/test/ui-lovelace.yaml
@@ -1,5 +1,7 @@
 decluttering_templates: !include decluttering-templates.yaml
 button_card_templates: !include button-card-templates.yaml
+button_card_templates_url:
+  - /local/workspace/test/www/url-templates.yaml
 
 views:
   - !include lovelace/01_main.yaml

--- a/test/ui-lovelace.yaml
+++ b/test/ui-lovelace.yaml
@@ -13,6 +13,7 @@ views:
   - !include lovelace/07_styling.yaml
   - !include lovelace/08_layouts.yaml
   - !include lovelace/09_custom_fields.yaml
+  - !include lovelace/10_config_templates.yaml
 
   - !include lovelace/20_decluttering.yaml
 

--- a/test/www/url-templates.yaml
+++ b/test/www/url-templates.yaml
@@ -1,7 +1,11 @@
-extraS3:
-  extra_styles: |
-    [[[
-      return `#name {
-        color: ${entity.state === 'on' ? 'blue' : 'purple'};
-      }`;
-    ]]]
+simple_template_url:
+  template:
+    - label_bold
+  styles:
+    icon:
+      - color: green
+
+simple_template_override:
+  styles:
+    icon:
+      - color: green

--- a/test/www/url-templates.yaml
+++ b/test/www/url-templates.yaml
@@ -1,0 +1,7 @@
+extraS3:
+  extra_styles: |
+    [[[
+      return `#name {
+        color: ${entity.state === 'on' ? 'blue' : 'purple'};
+      }`;
+    ]]]

--- a/yarn.lock
+++ b/yarn.lock
@@ -8226,6 +8226,11 @@ yallist@^5.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
   integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
+yaml@^2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.3.tgz#a0d6bd2efb3dd03c59370223701834e60409bd7d"
+  integrity sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==
+
 yargs-parser@^20.2.2:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"


### PR DESCRIPTION
Fixes #1153

This pull request introduces support for loading button-card templates from external URLs, in addition to existing local configuration options. It updates the documentation to explain new template loading methods, implements the logic for fetching and merging templates from URLs, and adds tests and examples to demonstrate the new functionality. The changes also clarify template precedence and merging behavior.

Key changes include:

**Feature: Load Templates from URL**
* Added support for specifying `button_card_templates_url` in Lovelace configuration, allowing templates to be loaded from one or more URLs (local or external). Templates from URLs are fetched, parsed as YAML, and merged with local templates, with local templates taking precedence if there are conflicts. [[1]](diffhunk://#diff-a52ea2eb903aabe416ffb95dfd846a11a2f752250a95b43e289df465a4d56aeaL1681-R1726) [[2]](diffhunk://#diff-a52ea2eb903aabe416ffb95dfd846a11a2f752250a95b43e289df465a4d56aeaR139-R140) [[3]](diffhunk://#diff-a52ea2eb903aabe416ffb95dfd846a11a2f752250a95b43e289df465a4d56aeaR111) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L77-R78) [[5]](diffhunk://#diff-e636c4e65cb9e508a4ea1c9d24b079a6abe7ea70ef93509d975345e8e656ff7eR3-R4) [[6]](diffhunk://#diff-4a6239e90d1f78c97db3eef89ba8db4d2ff447ae20a19c386750813d685d59bbR1-R11)

**Documentation Updates**
* Expanded documentation in `config-templates.md` to explain how to load templates directly, use YAML includes, and load templates from URLs. Added security warnings and clarified merging and precedence rules for templates from multiple sources. [[1]](diffhunk://#diff-b4b8c685221368308f7066f7be02b1e825dfbb4d4d82527093668aa549c3be3fL20-R44) [[2]](diffhunk://#diff-b4b8c685221368308f7066f7be02b1e825dfbb4d4d82527093668aa549c3be3fR71-R133)

**Template Merging and Precedence**
* Clarified and implemented logic so that if a template is defined both locally and in a URL, the local definition takes precedence. If a template is defined in multiple URLs, the last one defined wins. Merging of multiple templates and local overrides is also clarified and tested. [[1]](diffhunk://#diff-a52ea2eb903aabe416ffb95dfd846a11a2f752250a95b43e289df465a4d56aeaL1690-R1736) [[2]](diffhunk://#diff-a52ea2eb903aabe416ffb95dfd846a11a2f752250a95b43e289df465a4d56aeaL1681-R1726) [[3]](diffhunk://#diff-a52ea2eb903aabe416ffb95dfd846a11a2f752250a95b43e289df465a4d56aeaL1719-R1763)

**Testing and Examples**
* Added test templates and example Lovelace dashboards to verify template loading and merging from both local and URL sources, including nested and overridden templates. [[1]](diffhunk://#diff-2898cb413ece5f4eccb37cebeab02889a3e1edb84dfd0d508012e2548330eab0R334-R367) [[2]](diffhunk://#diff-36461986353dea4ef6f5c7bfd610f7fc13923c49f8610c1a7af5bf28738f42c8R1-R42) [[3]](diffhunk://#diff-e636c4e65cb9e508a4ea1c9d24b079a6abe7ea70ef93509d975345e8e656ff7eR16)

**Dependency Update**
* Added the `yaml` npm package to support parsing YAML files loaded from URLs.

These changes make button-card configuration more flexible and reusable, especially for setups with multiple dashboards or shared template repositories.